### PR TITLE
add the edit and view resume feature by uuid

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -55,6 +55,9 @@ jobs:
       env:
         TF_VAR_cloudflare_email: ${{ secrets.CLOUDFLARE_EMAIL }}
         TF_VAR_cloudflare_api_key: ${{ secrets.CLOUDFLARE_API_KEY }}
+        TF_VAR_app_s3_bucket_name: ${{ secrets.APP_S3_BUCKET_NAME }}
+        TF_VAR_app_s3_prefix: ${{ secrets.APP_S3_PREFIX }}
+        TF_VAR_share_token_key: ${{ secrets.SHARE_TOKEN_KEY }}
 
     # Validate Terraform configuration
     - name: Terraform Validate
@@ -80,6 +83,9 @@ jobs:
       env:
         TF_VAR_cloudflare_email: ${{ secrets.CLOUDFLARE_EMAIL }}
         TF_VAR_cloudflare_api_key: ${{ secrets.CLOUDFLARE_API_KEY }}
+        TF_VAR_app_s3_bucket_name: ${{ secrets.APP_S3_BUCKET_NAME }}
+        TF_VAR_app_s3_prefix: ${{ secrets.APP_S3_PREFIX }}
+        TF_VAR_share_token_key: ${{ secrets.SHARE_TOKEN_KEY }}
 
     # Generate Terraform plan and check for changes
     - name: Terraform Plan
@@ -90,6 +96,9 @@ jobs:
       env:
         TF_VAR_cloudflare_email: ${{ secrets.CLOUDFLARE_EMAIL }}
         TF_VAR_cloudflare_api_key: ${{ secrets.CLOUDFLARE_API_KEY }}
+        TF_VAR_app_s3_bucket_name: ${{ secrets.APP_S3_BUCKET_NAME }}
+        TF_VAR_app_s3_prefix: ${{ secrets.APP_S3_PREFIX }}
+        TF_VAR_share_token_key: ${{ secrets.SHARE_TOKEN_KEY }}
       continue-on-error: true
 
     # Apply Terraform changes (only if there are changes)
@@ -99,6 +108,9 @@ jobs:
       env:
         TF_VAR_cloudflare_email: ${{ secrets.CLOUDFLARE_EMAIL }}
         TF_VAR_cloudflare_api_key: ${{ secrets.CLOUDFLARE_API_KEY }}
+        TF_VAR_app_s3_bucket_name: ${{ secrets.APP_S3_BUCKET_NAME }}
+        TF_VAR_app_s3_prefix: ${{ secrets.APP_S3_PREFIX }}
+        TF_VAR_share_token_key: ${{ secrets.SHARE_TOKEN_KEY }}
 
     # Get EC2 instance ID for reboot (only if no changes)
     - name: Get EC2 Instance ID
@@ -138,6 +150,9 @@ jobs:
       env:
         TF_VAR_cloudflare_email: ${{ secrets.CLOUDFLARE_EMAIL }}
         TF_VAR_cloudflare_api_key: ${{ secrets.CLOUDFLARE_API_KEY }}
+        TF_VAR_app_s3_bucket_name: ${{ secrets.APP_S3_BUCKET_NAME }}
+        TF_VAR_app_s3_prefix: ${{ secrets.APP_S3_PREFIX }}
+        TF_VAR_share_token_key: ${{ secrets.SHARE_TOKEN_KEY }}
 
     # Reboot EC2 instance (only if no changes)
     - name: Reboot EC2 Instance

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ cv-generator/
 │   ├── models/
 │   │   └── cv_data.py          # Pydantic models for data validation
 │   ├── services/
-│   │   └── cv_service.py       # Business logic layer
-│   ├── core/
-│   │   ├── exceptions.py       # Custom exceptions
-│   │   └── logging.py          # Logging configuration
-│   └── utils/
-├── templates/                   # Jinja2 templates
+│   │   ├── cv_service.py       # Business logic layer
+│   │   └── resume_storage_service.py  # UUID-based draft storage
+│   └── core/
+│       ├── exceptions.py       # Custom exceptions
+│       └── logging.py          # Logging configuration
+├── templates/                   # Jinja2 templates (web + PDF)
 ├── static/                      # Static assets
 ├── generated/                   # Generated CV files
 ├── main.py                      # FastAPI application
@@ -90,6 +90,9 @@ logger.error(f"Error generating PDF: {str(e)}")
 # Install dependencies
 pip install -r requirements.txt
 
+# Install Playwright browser (required for PDF generation)
+playwright install chromium
+
 # Run the application
 uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 ```
@@ -97,11 +100,16 @@ uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 ### API Endpoints
 
 #### Web Interface
-- `GET /` - CV form
+- `GET /` - Creates a new resume UUID and redirects to `/resume/{resume_id}`
+- `GET /resume/{resume_id}` - Edit form for that resume (draft-aware)
+- `POST /resume/{resume_id}/save` - Save draft data
+- `GET /resume/{resume_id}/view` - View-only mode for sharing
+- `GET /resume/{resume_id}/share` - Returns shareable link JSON
 - `GET /test` - Pre-filled test form
-- `POST /generate` - Generate CV from form data
-- `GET /cv/{cv_id}` - View CV with download button
-- `GET /cv/{cv_id}/pdf` - Download PDF
+- `POST /generate` - Generate CV from form data (supports legacy and dynamic formats; can direct-download PDF)
+- `GET /cv/{cv_id}` - View generated CV with download button
+- `GET /cv/{cv_id}/html` - Raw HTML CV
+- `GET /cv/{cv_id}/pdf` - On-demand PDF generation via Playwright
 
 #### API Endpoints
 - `GET /api/v1/cvs` - List all CVs

--- a/RESUME_FEATURE_README.md
+++ b/RESUME_FEATURE_README.md
@@ -1,0 +1,191 @@
+# Resume Editing and Sharing Feature
+
+This document describes the new UUID-based resume editing and sharing functionality added to the CV Generator.
+
+## Overview
+
+The CV Generator now supports:
+- **Persistent Resume Storage**: Each resume gets a unique UUID and is saved locally
+- **Auto-save**: Form data is automatically saved as you type
+- **Resume Editing**: Return to edit your resume using the saved URL
+- **Resume Sharing**: Share completed resumes with others in view-only mode
+- **URL Management**: Easy copying of edit and share URLs
+
+## How It Works
+
+### 1. Creating a New Resume
+- Visit the main URL (`/`)
+- A new UUID is automatically generated
+- You're redirected to `/resume/{uuid}` where you can fill out the form
+
+### 2. Auto-save Functionality
+- Form data is automatically saved every 2 seconds after you stop typing
+- Draft data is saved locally in the `resume_data/` folder
+- Each resume has a JSON file with the UUID as the filename
+
+### 3. Returning to Edit
+- Copy the current URL (e.g., `/resume/abc123-def456`)
+- When you return to this URL, your previous data will be loaded
+- You can continue editing from where you left off
+
+### 4. Sharing Resumes
+- Share your resume anytime (even if not completed) by clicking "Share URL"
+- Use the share URL (e.g., `/resume/abc123-def456/view`)
+- Others can view your resume but cannot edit it
+- Draft resumes show a warning that they may be incomplete
+
+## File Structure
+
+```
+resume_data/
+├── resume_metadata.json          # Index of all resumes
+├── abc123-def456.json           # Individual resume data
+├── ghi789-jkl012.json           # Another resume
+└── ...
+```
+
+## API Endpoints
+
+### Resume Management
+- `GET /` - Create new resume and redirect to UUID-based URL
+- `GET /resume/{uuid}` - Edit resume (loads existing data if available)
+- `GET /resume/{uuid}/view` - View-only mode for shared resumes (no edit form, works for drafts too)
+- `POST /resume/{uuid}/save` - Save draft data (auto-save endpoint)
+- `GET /resume/{uuid}/share` - Get shareable link (works for any resume status)
+
+### Existing Endpoints
+- `POST /generate` - Generate CV (now supports resume_id)
+- `GET /cv/{cv_id}` - View generated CV
+- `GET /cv/{cv_id}/pdf` - Download PDF
+
+## Features
+
+### Auto-save
+- Saves every 2 seconds after user stops typing
+- No notifications shown to avoid spam (automatic background saving)
+- Saves on form submission
+
+### URL Copy Popup
+- Warns users before closing the tab if resume is not completed
+- Shows message: "Please copy the URL to edit later your resume."
+- Provides easy copy buttons for both edit and share URLs
+
+### Resume Information Panel
+- Shows current resume ID
+- Displays edit URL with copy button (for returning to edit)
+- Shows share URL with copy button (for sharing with others)
+- Provides helpful tips and auto-save status
+
+### View-only Mode
+- Any resume (completed or draft) can be shared via `/resume/{uuid}/view`
+- Shows banner indicating it's a shared resume
+- No editing capabilities
+- Clean, professional appearance
+- Draft resumes show a warning about being incomplete
+
+### Button Functionality
+- **Copy Edit URL**: Copies the current URL for returning to edit later
+- **Copy Share URL**: Saves current draft and copies the shareable link to clipboard
+- **Auto-save**: Works silently in background every 2 seconds
+
+## Technical Implementation
+
+### Storage Service
+- `ResumeStorageService` class handles all storage operations
+- Supports local file storage (easily extensible to S3)
+- Maintains metadata index for quick lookups
+- Handles cleanup of old incomplete resumes
+
+### Data Persistence
+- Resume data is stored in structured JSON format
+- Includes creation and modification timestamps
+- Tracks completion status
+- Compatible with existing CV data models
+
+### Error Handling
+- Graceful fallbacks if storage operations fail
+- Logging for debugging and monitoring
+- User-friendly error messages
+
+## Future Enhancements
+
+### S3 Integration
+- The storage service is designed to easily switch to S3
+- Factory pattern allows different storage backends
+- Metadata structure remains consistent
+
+### User Authentication
+- Could add user accounts to manage multiple resumes
+- Resume ownership and privacy controls
+- Collaboration features
+
+### Resume Templates
+- Multiple CV templates/styles
+- Template switching without losing data
+- Custom styling options
+
+## Usage Examples
+
+### For Resume Creators
+1. Visit the CV Generator
+2. Fill out your resume information (auto-saves every 2 seconds)
+3. Copy the Edit URL to return later
+4. Click "Copy Share URL" to copy the shareable link
+5. Share the copied URL with others for view-only access
+
+### For Resume Viewers
+1. Click on a shared resume link
+2. View the resume in read-only mode
+3. Download as PDF if needed
+4. Create your own resume using the main generator
+
+## Configuration
+
+### Storage Type
+- Currently set to "local" storage
+- Can be changed to "s3" in the future
+- Storage path is configurable
+
+### Auto-save Timing
+- Default: 2 seconds after user stops typing
+- Configurable in the JavaScript code
+- Can be adjusted based on user preferences
+
+### Cleanup Settings
+- Old incomplete resumes are cleaned up after 30 days
+- Configurable cleanup interval
+- Helps manage storage space
+
+## Troubleshooting
+
+### Resume Not Loading
+- Check if the UUID is correct
+- Verify the resume file exists in `resume_data/`
+- Check application logs for errors
+
+### Auto-save Not Working
+- Ensure JavaScript is enabled
+- Check browser console for errors
+- Verify the resume_id is present
+
+### Storage Issues
+- Check disk space in the `resume_data/` folder
+- Verify file permissions
+- Check application logs for storage errors
+
+## Security Considerations
+
+### Data Privacy
+- Resume data is stored locally by default
+- No data is sent to external services
+- Users control their own data
+
+### URL Security
+- UUIDs are randomly generated
+- No sequential or predictable patterns
+- URLs are not indexed by search engines
+
+### Access Control
+- Anyone with the URL can view/edit (if not completed)
+- Consider adding authentication for production use
+- Implement rate limiting for storage operations

--- a/S3_DEPLOYMENT_GUIDE.md
+++ b/S3_DEPLOYMENT_GUIDE.md
@@ -1,0 +1,242 @@
+# S3-Backed Resume Storage Deployment Guide
+
+## What We've Implemented
+
+✅ **Code Changes Complete:**
+- Added `boto3>=1.34.0` to requirements.txt
+- Implemented `S3ResumeStorageService` in `app/services/resume_storage_service.py`
+- Updated factory to read environment variables and switch between local/S3 storage
+- Modified `main.py` to use `RESUME_STORAGE_TYPE` environment variable
+- Added Terraform resources for S3 bucket, IAM policy, and environment variables
+- Updated user data script to set S3 environment variables in production
+
+## What You Need to Do Now
+
+### Step 1: Configure Terraform Variables
+
+Update your `terraform/terraform.tfvars` file with the new S3 bucket name:
+
+```hcl
+# Existing variables...
+aws_region = "ap-south-1"
+project_name = "cv-generator"
+cloudflare_email = "your-email@example.com"
+cloudflare_api_key = "your-api-key"
+cloudflare_zone_name = "avantifellows.org"
+domain = "cv-generator"
+repo_url = "https://github.com/your-username/cv-generator.git"
+
+# NEW: S3 Configuration
+app_s3_bucket_name = "cv-generator-app-storage-unique-suffix"  # Must be globally unique
+app_s3_prefix = "prod/"  # Optional: use "" for no prefix
+```
+
+**Important:** The S3 bucket name must be globally unique across all AWS accounts. Consider using a suffix like your organization name or random string.
+
+### Step 2: Deploy Terraform Infrastructure
+
+```bash
+cd terraform
+
+# Initialize (if not already done)
+terraform init
+
+# Plan the changes - you should see new S3 resources
+terraform plan
+
+# Apply the changes
+terraform apply
+```
+
+**What this creates:**
+- S3 bucket with versioning, encryption, and public access blocked
+- IAM policy granting the EC2 instance access to the bucket
+- Updates the systemd service with S3 environment variables
+
+### Step 3: Deploy Application Code
+
+Since you're on the `feature/edit-view-by-uuid` branch, you need to merge/push your S3 changes:
+
+```bash
+# Commit your S3 implementation
+git add .
+git commit -m "Implement S3-backed resume storage"
+
+# Push to your branch (update the terraform repo_url to point to your branch)
+git push origin feature/edit-view-by-uuid
+```
+
+**OR** merge to main and update `repo_url` in terraform.tfvars to point to main branch.
+
+### Step 4: Update the EC2 Instance
+
+After Terraform applies successfully:
+
+```bash
+# SSH into your instance
+ssh -i ~/.ssh/AvantiFellows.pem ubuntu@<ELASTIC_IP>
+
+# Switch to app user
+sudo su - cvapp
+cd /home/cvapp/app
+
+# Pull latest changes
+git pull origin feature/edit-view-by-uuid  # or main
+
+# Install new dependencies
+./venv/bin/pip install -r requirements.txt
+
+# Exit back to ubuntu user
+exit
+
+# Restart the service to pick up new environment variables
+sudo systemctl restart cv-generator
+
+# Check service status
+sudo systemctl status cv-generator
+```
+
+### Step 5: Verify S3 Storage is Working
+
+1. **Check application logs:**
+```bash
+sudo journalctl -u cv-generator -f
+```
+
+2. **Test the application:**
+- Visit your app: `https://cv-generator.avantifellows.org`
+- Create a new resume (should see S3 logs)
+- Save a draft (should see S3 PUT operations)
+
+3. **Check S3 bucket:**
+```bash
+# List objects in your bucket
+aws s3 ls s3://your-bucket-name/prod/resumes/
+aws s3 ls s3://your-bucket-name/prod/metadata/
+```
+
+You should see JSON files with UUID names appearing in the `resumes/` prefix.
+
+## Environment Variables Reference
+
+### Production (automatically set by Terraform):
+```bash
+RESUME_STORAGE_TYPE=s3
+S3_BUCKET_NAME=your-bucket-name
+S3_PREFIX=prod/
+AWS_REGION=ap-south-1
+```
+
+### Local Development Options:
+
+**Option 1: Default (recommended for most development)**
+```bash
+# No environment variables needed - uses local files
+uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+```
+
+**Option 2: Test S3 locally**
+```bash
+# Copy the example file
+cp env.example .env
+
+# Edit .env with your test bucket details:
+RESUME_STORAGE_TYPE=s3
+S3_BUCKET_NAME=your-test-bucket-name
+S3_PREFIX=dev/
+AWS_REGION=ap-south-1
+
+# Ensure AWS credentials are configured
+aws configure  # or set AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+
+# Run the app
+uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+```
+
+**Note:** The app automatically detects if a `.env` file exists and loads it for local development. On the server, no `.env` file exists, so it uses the environment variables set by systemd.
+
+## Troubleshooting
+
+### Issue: App fails to start with S3 errors
+
+**Check:**
+1. Verify IAM role is attached: `aws sts get-caller-identity`
+2. Test S3 access: `aws s3 ls s3://your-bucket-name/`
+3. Check environment variables: `sudo systemctl show cv-generator | grep Environment`
+
+**Common fixes:**
+- Ensure bucket name in terraform.tfvars matches exactly
+- Verify IAM policy was attached to EC2 role
+- Check bucket exists in correct region
+
+### Issue: "Bucket does not exist" error
+
+**Fix:** Ensure `terraform apply` completed successfully and created the bucket.
+
+### Issue: Access denied errors
+
+**Fix:** Verify the IAM policy allows access to the correct bucket and prefixes.
+
+### Issue: App still using local storage
+
+**Fix:** Verify environment variables are set in systemd service:
+```bash
+sudo systemctl show cv-generator | grep Environment
+```
+
+## Migration from Local to S3 (Optional)
+
+If you have existing local resume drafts you want to keep:
+
+```bash
+# On the EC2 instance
+sudo su - cvapp
+cd /home/cvapp/app
+
+# Sync existing local drafts to S3
+aws s3 sync resume_data/ s3://your-bucket-name/prod/resumes/ \
+  --exclude "resume_metadata.json"
+
+# Copy metadata file
+aws s3 cp resume_data/resume_metadata.json \
+  s3://your-bucket-name/prod/metadata/resume_metadata.json
+```
+
+## Testing Checklist
+
+- [ ] Terraform apply successful
+- [ ] S3 bucket created with correct permissions
+- [ ] EC2 instance can access S3 bucket
+- [ ] Application starts without errors
+- [ ] Can create new resume (creates S3 object)
+- [ ] Can save draft (updates S3 object)  
+- [ ] Can view/edit existing resume (reads from S3)
+- [ ] Can delete resume (removes S3 object)
+- [ ] Local development still works with `RESUME_STORAGE_TYPE=local`
+
+## What Happens Next
+
+After successful deployment:
+1. **All new resume drafts** will be stored in S3
+2. **Local files in `resume_data/`** will no longer be used (but won't be deleted)
+3. **The app will work identically** from user perspective
+4. **Drafts persist** even if EC2 instance is replaced
+5. **You can access drafts** directly via AWS CLI/Console if needed
+
+## Rollback Plan
+
+If issues occur, you can quickly rollback:
+
+```bash
+# SSH to instance
+sudo su - cvapp
+
+# Edit the systemd service to use local storage
+sudo sed -i 's/RESUME_STORAGE_TYPE=s3/RESUME_STORAGE_TYPE=local/' /etc/systemd/system/cv-generator.service
+
+# Restart service
+sudo systemctl daemon-reload
+sudo systemctl restart cv-generator
+```
+
+This switches back to local file storage immediately.

--- a/S3_Resume_Storage_Design.md
+++ b/S3_Resume_Storage_Design.md
@@ -1,0 +1,266 @@
+# S3-backed Resume Storage Design & Implementation Plan
+
+## Overview
+
+This document proposes migrating resume draft persistence from local JSON files in `resume_data/` to Amazon S3. S3 will act as the source of truth (“database”) for all resume drafts keyed by UUID. We will keep the current web/API behaviors unchanged by introducing an S3-backed implementation of the existing `ResumeStorageService` interface.
+
+## Goals
+
+- Use S3 to store and retrieve resume drafts by UUID.
+- Maintain the same user flows and endpoints; no API changes required.
+- Keep local mode for development; enable S3 mode in production via configuration.
+- Manage the S3 bucket and IAM through the existing Terraform setup.
+
+## Non-Goals
+
+- Moving generated CV HTML/PDF to S3 (can be a future enhancement).
+- Adding user accounts or auth. The change is storage-only.
+
+## Current State (Relevant Pieces)
+
+- `ResumeStorageService` (local): stores drafts as `resume_data/{resume_id}.json` and tracks metadata in `resume_data/resume_metadata.json`.
+- Endpoints using it:
+  - `GET /resume/{resume_id}` (exists, load or create shell)
+  - `POST /resume/{resume_id}/save` (update draft)
+  - `GET /resume/{resume_id}/view` (view-only mode)
+  - `GET /resume/{resume_id}/share` (share link)
+- Factory function `create_resume_storage_service(base_path, storage_type)` exists; `"s3"` branch is unimplemented.
+
+## Proposed Architecture
+
+- Implement `S3ResumeStorageService` with the same public methods as the local service.
+- Switch via environment config (default `local`, prod uses `s3`).
+- Store one JSON object per resume in S3; optionally maintain a compact metadata index for faster listing (best-effort cache).
+
+### S3 Object Layout
+
+- Bucket: managed by Terraform (private, versioned, encrypted, public access blocked).
+- Optional prefix (environmental): e.g., `prod/`.
+- Keys:
+  - `resumes/{resume_id}.json` — full resume JSON: `{ resume_id, created_at, last_modified, data, is_completed }`.
+  - `metadata/resume_metadata.json` — optional aggregate index for faster `list_resumes` (best effort; rebuildable).
+
+### Service Behavior Mapping
+
+- `create_new_resume(initial_data, resume_id)`: Generate or use provided UUID, write JSON to `resumes/{resume_id}.json`, update metadata index (if used).
+- `resume_exists(resume_id)`: S3 `HEAD` on `resumes/{resume_id}.json`.
+- `get_resume_data(resume_id)`: `GET` object and `json.loads`.
+- `update_resume_data(resume_id, data, is_completed)`: `GET` -> mutate `last_modified`/`is_completed` -> `PUT` back; update index (if used).
+- `delete_resume(resume_id)`: `DELETE` object; remove from index.
+- `list_resumes()`: Prefer `ListObjectsV2` on `resumes/` and build a list (accurate, O(n)); fallback/use index if present for faster results.
+- `cleanup_old_resumes(days_old)`: Use S3 `LastModified` as a quick filter; optionally `GET` JSON to confirm `is_completed` before deletion.
+
+### Robustness
+
+- Retries/Timeouts: `botocore.config.Config(retries={'max_attempts': 10, 'mode': 'adaptive'}, connect_timeout=5, read_timeout=20)`.
+- Concurrency: Low contention; index updates are best-effort; source of truth is per-resume objects.
+- Observability: Log bucket/key and request IDs where possible.
+
+### Security
+
+- Bucket private with block public access; TLS in transit; SSE-S3 (or SSE-KMS) at rest.
+- IAM scoped to the application EC2 role:
+  - `s3:ListBucket` on the bucket
+  - `s3:GetObject|PutObject|DeleteObject` on `resumes/*` and `metadata/*`
+
+## Configuration
+
+Environment variables (read in `main.py`):
+
+- `RESUME_STORAGE_TYPE` — `local` (default) or `s3`.
+- `S3_BUCKET_NAME` — required in `s3` mode.
+- `S3_PREFIX` — optional (e.g., `prod/`).
+- `AWS_REGION` — optional; otherwise rely on instance metadata/role.
+
+## Terraform Changes
+
+Add a dedicated bucket and IAM permissions in `terraform/`:
+
+1) Variables (in `variables.tf`):
+
+```hcl
+variable "app_s3_bucket_name" { type = string }
+variable "app_s3_prefix" { type = string, default = "" }
+```
+
+2) Bucket (in `main.tf`):
+
+```hcl
+resource "aws_s3_bucket" "app_bucket" {
+  bucket = var.app_s3_bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "app_bucket" {
+  bucket = aws_s3_bucket.app_bucket.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "app_bucket" {
+  bucket = aws_s3_bucket.app_bucket.id
+  rule {
+    apply_server_side_encryption_by_default { sse_algorithm = "AES256" }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "app_bucket" {
+  bucket                  = aws_s3_bucket.app_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+```
+
+3) IAM policy attachment (scope to bucket and prefixes) for existing EC2 role:
+
+```hcl
+data "aws_iam_policy_document" "app_s3_access" {
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.app_bucket.arn]
+  }
+
+  statement {
+    actions = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = [
+      "${aws_s3_bucket.app_bucket.arn}/${var.app_s3_prefix}resumes/*",
+      "${aws_s3_bucket.app_bucket.arn}/${var.app_s3_prefix}metadata/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "app_s3_policy" {
+  name   = "cv-generator-app-s3"
+  policy = data.aws_iam_policy_document.app_s3_access.json
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_app_s3" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = aws_iam_policy.app_s3_policy.arn
+}
+```
+
+4) Outputs (optional):
+
+```hcl
+output "app_s3_bucket_name" { value = aws_s3_bucket.app_bucket.bucket }
+output "app_s3_bucket_arn"  { value = aws_s3_bucket.app_bucket.arn }
+```
+
+## Application Code Changes
+
+1) Dependencies
+
+Add to `requirements.txt`:
+
+```
+boto3>=1.34.0
+```
+
+2) Implement `S3ResumeStorageService` in `app/services/resume_storage_service.py`
+
+- Mirror the local service’s public API: `create_new_resume`, `get_resume_data`, `update_resume_data`, `resume_exists`, `delete_resume`, `list_resumes`, `cleanup_old_resumes`.
+- Helper methods to build keys: `_resume_key(resume_id)`, `_metadata_key()`.
+- Initialize a boto3 S3 client with retry config and optional region.
+
+3) Factory update
+
+- Update `create_resume_storage_service(base_path, storage_type)` to return an instance of the S3 implementation when `storage_type == "s3"` using environment variables for bucket/prefix.
+
+4) Initialization in `main.py`
+
+- Read env vars and create the appropriate service:
+
+```python
+import os
+from app.services.resume_storage_service import create_resume_storage_service
+
+storage_type = os.getenv("RESUME_STORAGE_TYPE", "local")
+resume_storage_service = create_resume_storage_service(
+    BASE_PATH,
+    storage_type,
+)
+```
+
+If the S3 implementation needs bucket/prefix/region, wire them in the factory via env reads (to avoid touching `main.py` signature).
+
+5) README update
+
+- Document environment variables and Terraform steps for enabling S3 mode.
+
+## Migration & Rollout
+
+1) Deploy Terraform to create bucket and attach IAM policy.
+
+2) One-time data push (optional, to keep existing drafts):
+
+```bash
+# Upload each local draft to S3 resumes prefix
+aws s3 sync resume_data/ s3://$APP_S3_BUCKET/$APP_S3_PREFIX/resumes/ \
+  --exclude "*" --include "*.json" --no-progress
+
+# If keeping the metadata index
+aws s3 cp resume_data/resume_metadata.json \
+  s3://$APP_S3_BUCKET/$APP_S3_PREFIX/metadata/resume_metadata.json
+```
+
+3) Configure environment for the app (systemd or .env):
+
+```bash
+export RESUME_STORAGE_TYPE=s3
+export S3_BUCKET_NAME=<your-bucket>
+export S3_PREFIX=prod/
+export AWS_REGION=ap-south-1
+```
+
+4) Restart the service and verify flows:
+
+- Create a new resume, save, view, share.
+- Confirm objects appear in S3 and are readable via the app.
+
+## Testing Strategy
+
+- Unit tests with `moto` to mock S3 covering: create, exists, get, update, delete, list, cleanup.
+- Integration smoke tests running the app in S3 mode (with real or mocked credentials).
+- Edge cases: non-existent IDs, large payloads, transient S3 errors (retry logic).
+
+## Security & Compliance
+
+- Encrypted at rest (SSE), TLS enforced in transit, public access blocked.
+- Least-privilege IAM scoped to exact prefixes.
+- Optionally enable S3 server access logs to a separate logging bucket.
+
+## Future Enhancements
+
+- Store generated CV HTML/PDF in S3 and serve via signed URLs or proxy.
+- Replace metadata JSON with DynamoDB for scalable listings while continuing to store per-resume JSON in S3.
+- Async S3 client (`aioboto3`) for non-blocking I/O under higher load.
+
+## Implementation Checklist
+
+- Terraform
+  - [ ] Add bucket with versioning, SSE, public access block
+  - [ ] Add IAM policy and attach to EC2 role
+  - [ ] Add variables and outputs
+- App
+  - [ ] Add `boto3` to `requirements.txt`
+  - [ ] Implement `S3ResumeStorageService`
+  - [ ] Update factory to return local or S3 implementation
+  - [ ] Read env vars in `main.py` (via factory) and initialize
+  - [ ] Update README with configuration instructions
+- Data (optional)
+  - [ ] Sync existing local drafts to S3
+- Tests
+  - [ ] Unit tests for S3 implementation using `moto`
+  - [ ] Integration smoke tests in S3 mode
+
+## Acceptance Criteria
+
+- With `RESUME_STORAGE_TYPE=s3`:
+  - Creating, saving, viewing, deleting resumes works as before but persists in S3.
+  - `list_resumes()` returns correct data via S3 listing or index.
+  - Terraform provisions the bucket and IAM; the instance can access S3 via its role.
+- With `RESUME_STORAGE_TYPE=local`:
+  - Existing local behavior remains unchanged.
+
+

--- a/app.log
+++ b/app.log
@@ -2850,3 +2850,532 @@ NameError: name 'async_playwright' is not defined
 2025-07-24 00:56:45,489 - main - INFO - Starting PDF generation with Playwright
 2025-07-24 00:56:48,493 - main - INFO - PDF generated successfully, size: 157360 bytes
 2025-07-24 00:56:48,493 - main - INFO - PDF generated successfully for CV: 94148f48-134c-4bd9-a06c-2b07790acc2b
+2025-08-20 16:24:29,089 - app.services.resume_storage_service - INFO - Created new resume with ID: 9b7a6b0a-37f8-46f1-8a5e-26755d74dc24
+2025-08-20 16:24:56,761 - app.services.resume_storage_service - INFO - Created new resume with ID: f1610e62-e4cb-4988-98cd-3c2e14f369a3
+2025-08-20 16:27:22,651 - app.services.resume_storage_service - INFO - Created new resume with ID: c297c36c-86b9-4d63-ba54-c92a69233e9d
+2025-08-20 16:27:22,652 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: c297c36c-86b9-4d63-ba54-c92a69233e9d
+2025-08-20 16:28:08,098 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: c297c36c-86b9-4d63-ba54-c92a69233e9d
+2025-08-20 16:29:41,588 - app.services.resume_storage_service - INFO - Created new resume with ID: 105724ff-593c-40eb-8b52-1a6fec1d8e50
+2025-08-20 16:29:41,590 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 105724ff-593c-40eb-8b52-1a6fec1d8e50
+2025-08-20 17:41:15,171 - app.services.resume_storage_service - INFO - Created new resume with ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:41:15,173 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:41:34,476 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:41:39,628 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:41:56,467 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 17:41:56,467 - main - INFO -   - title_font_size: 12px
+2025-08-20 17:41:56,467 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 17:41:56,467 - main - INFO -   - body_font_size: 12px
+2025-08-20 17:41:56,468 - main - INFO -   - body_font_color: #000000
+2025-08-20 17:41:56,468 - main - INFO -   - line_height: 1.1
+2025-08-20 17:41:56,468 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 17:41:56,468 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '—',
+                   'email': 'notfilled@email.com',
+                   'full_name': '—',
+                   'github': '',
+                   'highest_education': '—',
+                   'linkedin': '',
+                   'phone': '—'},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 17:41:56,469 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:41:56,470 - app.services.resume_storage_service - INFO - Updated resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:42:01,234 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 17:42:01,235 - main - INFO -   - title_font_size: 12px
+2025-08-20 17:42:01,235 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 17:42:01,235 - main - INFO -   - body_font_size: 12px
+2025-08-20 17:42:01,235 - main - INFO -   - body_font_color: #000000
+2025-08-20 17:42:01,235 - main - INFO -   - line_height: 1.1
+2025-08-20 17:42:01,236 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 17:42:01,236 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '—',
+                   'email': 'notfilled@email.com',
+                   'full_name': 'asd',
+                   'github': '',
+                   'highest_education': '—',
+                   'linkedin': '',
+                   'phone': '—'},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 17:42:01,236 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:42:01,238 - app.services.resume_storage_service - INFO - Updated resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:42:05,203 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 17:42:05,203 - main - INFO -   - title_font_size: 12px
+2025-08-20 17:42:05,203 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 17:42:05,203 - main - INFO -   - body_font_size: 12px
+2025-08-20 17:42:05,203 - main - INFO -   - body_font_color: #000000
+2025-08-20 17:42:05,203 - main - INFO -   - line_height: 1.1
+2025-08-20 17:42:05,204 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 17:42:05,204 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '—',
+                   'email': 'notfilled@email.com',
+                   'full_name': '—',
+                   'github': '',
+                   'highest_education': '—',
+                   'linkedin': '',
+                   'phone': '—'},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 17:42:05,204 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:42:05,205 - app.services.resume_storage_service - INFO - Updated resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:42:07,465 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:42:20,989 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 17:42:20,989 - main - INFO -   - title_font_size: 12px
+2025-08-20 17:42:20,989 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 17:42:20,989 - main - INFO -   - body_font_size: 12px
+2025-08-20 17:42:20,989 - main - INFO -   - body_font_color: #000000
+2025-08-20 17:42:20,989 - main - INFO -   - line_height: 1.1
+2025-08-20 17:42:20,989 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 17:42:20,990 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '—',
+                   'email': 'notfilled@email.com',
+                   'full_name': 'ads',
+                   'github': '',
+                   'highest_education': '—',
+                   'linkedin': '',
+                   'phone': '—'},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 17:42:20,990 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:42:20,990 - app.services.resume_storage_service - INFO - Updated resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:42:23,989 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:43:17,476 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:43:23,966 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 17:43:23,966 - main - INFO -   - title_font_size: 12px
+2025-08-20 17:43:23,966 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 17:43:23,966 - main - INFO -   - body_font_size: 12px
+2025-08-20 17:43:23,966 - main - INFO -   - body_font_color: #000000
+2025-08-20 17:43:23,966 - main - INFO -   - line_height: 1.1
+2025-08-20 17:43:23,966 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 17:43:23,966 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '—',
+                   'email': 'notfilled@email.com',
+                   'full_name': 'ads',
+                   'github': '',
+                   'highest_education': '—',
+                   'linkedin': '',
+                   'phone': '—'},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 17:43:23,967 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:43:23,967 - app.services.resume_storage_service - INFO - Updated resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:43:28,035 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:43:48,765 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:54:14,053 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: e1d068b1-8f3f-4fb2-b55d-2749b3915e5f
+2025-08-20 17:54:22,565 - app.services.resume_storage_service - INFO - Created new resume with ID: 4237fb08-98f3-4c9b-b486-6de9b91c1548
+2025-08-20 17:54:22,567 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 4237fb08-98f3-4c9b-b486-6de9b91c1548
+2025-08-20 17:54:29,810 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 4237fb08-98f3-4c9b-b486-6de9b91c1548
+2025-08-20 17:54:54,971 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 4237fb08-98f3-4c9b-b486-6de9b91c1548
+2025-08-20 17:56:54,014 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 4237fb08-98f3-4c9b-b486-6de9b91c1548
+2025-08-20 17:59:20,151 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 4237fb08-98f3-4c9b-b486-6de9b91c1548
+2025-08-20 17:59:24,624 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 17:59:24,624 - main - INFO -   - title_font_size: 12px
+2025-08-20 17:59:24,624 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 17:59:24,624 - main - INFO -   - body_font_size: 12px
+2025-08-20 17:59:24,624 - main - INFO -   - body_font_color: #000000
+2025-08-20 17:59:24,624 - main - INFO -   - line_height: 1.1
+2025-08-20 17:59:24,624 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 17:59:24,625 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '—',
+                   'email': 'notfilled@email.com',
+                   'full_name': 'a',
+                   'github': '',
+                   'highest_education': '—',
+                   'linkedin': '',
+                   'phone': '—'},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 17:59:24,625 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 4237fb08-98f3-4c9b-b486-6de9b91c1548
+2025-08-20 17:59:24,625 - app.services.resume_storage_service - INFO - Updated resume data for ID: 4237fb08-98f3-4c9b-b486-6de9b91c1548
+2025-08-20 17:59:27,499 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 17:59:27,499 - main - INFO -   - title_font_size: 12px
+2025-08-20 17:59:27,499 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 17:59:27,499 - main - INFO -   - body_font_size: 12px
+2025-08-20 17:59:27,499 - main - INFO -   - body_font_color: #000000
+2025-08-20 17:59:27,499 - main - INFO -   - line_height: 1.1
+2025-08-20 17:59:27,499 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 17:59:27,499 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '—',
+                   'email': 'notfilled@email.com',
+                   'full_name': '—',
+                   'github': '',
+                   'highest_education': '—',
+                   'linkedin': '',
+                   'phone': '—'},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 17:59:27,499 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 4237fb08-98f3-4c9b-b486-6de9b91c1548
+2025-08-20 17:59:27,500 - app.services.resume_storage_service - INFO - Updated resume data for ID: 4237fb08-98f3-4c9b-b486-6de9b91c1548
+2025-08-20 17:59:29,034 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 4237fb08-98f3-4c9b-b486-6de9b91c1548
+2025-08-20 18:03:50,287 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 4237fb08-98f3-4c9b-b486-6de9b91c1548
+2025-08-20 18:04:32,603 - app.services.resume_storage_service - INFO - Created new resume with ID: 05cff839-0380-467d-a7f1-90e344f7c543
+2025-08-20 18:04:32,605 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 05cff839-0380-467d-a7f1-90e344f7c543
+2025-08-20 18:04:34,748 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 05cff839-0380-467d-a7f1-90e344f7c543
+2025-08-20 18:04:37,835 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 18:04:37,835 - main - INFO -   - title_font_size: 12px
+2025-08-20 18:04:37,835 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 18:04:37,835 - main - INFO -   - body_font_size: 12px
+2025-08-20 18:04:37,835 - main - INFO -   - body_font_color: #000000
+2025-08-20 18:04:37,836 - main - INFO -   - line_height: 1.1
+2025-08-20 18:04:37,836 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 18:04:37,836 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '—',
+                   'email': 'notfilled@email.com',
+                   'full_name': 'a',
+                   'github': '',
+                   'highest_education': '—',
+                   'linkedin': '',
+                   'phone': '—'},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 18:04:37,836 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 05cff839-0380-467d-a7f1-90e344f7c543
+2025-08-20 18:04:37,836 - app.services.resume_storage_service - INFO - Updated resume data for ID: 05cff839-0380-467d-a7f1-90e344f7c543
+2025-08-20 18:04:39,230 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 05cff839-0380-467d-a7f1-90e344f7c543
+2025-08-20 18:05:23,554 - app.services.resume_storage_service - INFO - Created new resume with ID: 9fec453c-b48c-4a87-b1ed-b3c7928d5324
+2025-08-20 18:05:23,556 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 9fec453c-b48c-4a87-b1ed-b3c7928d5324
+2025-08-20 18:05:27,729 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 18:05:27,729 - main - INFO -   - title_font_size: 12px
+2025-08-20 18:05:27,729 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 18:05:27,729 - main - INFO -   - body_font_size: 12px
+2025-08-20 18:05:27,729 - main - INFO -   - body_font_color: #000000
+2025-08-20 18:05:27,730 - main - INFO -   - line_height: 1.1
+2025-08-20 18:05:27,730 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 18:05:27,730 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '—',
+                   'email': 'notfilled@email.com',
+                   'full_name': 'asd',
+                   'github': '',
+                   'highest_education': '—',
+                   'linkedin': '',
+                   'phone': '—'},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 18:05:27,730 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 9fec453c-b48c-4a87-b1ed-b3c7928d5324
+2025-08-20 18:05:27,730 - app.services.resume_storage_service - INFO - Updated resume data for ID: 9fec453c-b48c-4a87-b1ed-b3c7928d5324
+2025-08-20 18:29:18,738 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 9fec453c-b48c-4a87-b1ed-b3c7928d5324
+2025-08-20 18:29:23,285 - app.services.resume_storage_service - INFO - Created new resume with ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:29:23,288 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:29:26,826 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 18:29:26,826 - main - INFO -   - title_font_size: 12px
+2025-08-20 18:29:26,826 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 18:29:26,826 - main - INFO -   - body_font_size: 12px
+2025-08-20 18:29:26,826 - main - INFO -   - body_font_color: #000000
+2025-08-20 18:29:26,826 - main - INFO -   - line_height: 1.1
+2025-08-20 18:29:26,826 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 18:29:26,826 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '',
+                   'email': '',
+                   'full_name': 'ads',
+                   'github': '',
+                   'highest_education': '',
+                   'linkedin': '',
+                   'phone': ''},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 18:29:26,827 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:29:26,827 - app.services.resume_storage_service - INFO - Updated resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:29:28,204 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:29:30,931 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:29:33,814 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:29:37,246 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 18:29:37,247 - main - INFO -   - title_font_size: 12px
+2025-08-20 18:29:37,247 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 18:29:37,247 - main - INFO -   - body_font_size: 12px
+2025-08-20 18:29:37,247 - main - INFO -   - body_font_color: #000000
+2025-08-20 18:29:37,247 - main - INFO -   - line_height: 1.1
+2025-08-20 18:29:37,247 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 18:29:37,247 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '',
+                   'email': '',
+                   'full_name': 'ads',
+                   'github': '',
+                   'highest_education': 'asd',
+                   'linkedin': '',
+                   'phone': ''},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 18:29:37,248 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:29:37,249 - app.services.resume_storage_service - INFO - Updated resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:35:18,842 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:35:22,794 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 18:35:22,794 - main - INFO -   - title_font_size: 12px
+2025-08-20 18:35:22,795 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 18:35:22,795 - main - INFO -   - body_font_size: 12px
+2025-08-20 18:35:22,795 - main - INFO -   - body_font_color: #000000
+2025-08-20 18:35:22,795 - main - INFO -   - line_height: 1.1
+2025-08-20 18:35:22,795 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 18:35:22,795 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '',
+                   'email': '',
+                   'full_name': 'aads',
+                   'github': '',
+                   'highest_education': 'asd',
+                   'linkedin': '',
+                   'phone': ''},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 18:35:22,796 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:35:22,797 - app.services.resume_storage_service - INFO - Updated resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:35:28,973 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 18:35:28,973 - main - INFO -   - title_font_size: 12px
+2025-08-20 18:35:28,973 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 18:35:28,973 - main - INFO -   - body_font_size: 12px
+2025-08-20 18:35:28,973 - main - INFO -   - body_font_color: #000000
+2025-08-20 18:35:28,973 - main - INFO -   - line_height: 1.1
+2025-08-20 18:35:28,973 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 18:35:28,973 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '',
+                   'email': '',
+                   'full_name': 'aadasd',
+                   'github': '',
+                   'highest_education': 'asd',
+                   'linkedin': '',
+                   'phone': ''},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 18:35:28,973 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:35:28,974 - app.services.resume_storage_service - INFO - Updated resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:35:30,820 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:35:34,110 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 18:35:34,110 - main - INFO -   - title_font_size: 12px
+2025-08-20 18:35:34,110 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 18:35:34,110 - main - INFO -   - body_font_size: 12px
+2025-08-20 18:35:34,110 - main - INFO -   - body_font_color: #000000
+2025-08-20 18:35:34,110 - main - INFO -   - line_height: 1.1
+2025-08-20 18:35:34,110 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 18:35:34,110 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '',
+                   'email': '',
+                   'full_name': 'aadasd ',
+                   'github': '',
+                   'highest_education': 'asd',
+                   'linkedin': '',
+                   'phone': ''},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 18:35:34,110 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 18:35:34,111 - app.services.resume_storage_service - INFO - Updated resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0

--- a/app.log
+++ b/app.log
@@ -3382,3 +3382,121 @@ NameError: name 'async_playwright' is not defined
 2025-08-20 20:53:42,978 - main - INFO - Loaded .env file for local development
 2025-08-20 20:53:42,987 - botocore.credentials - INFO - Found credentials in shared credentials file: ~/.aws/credentials
 2025-08-20 20:53:43,188 - app.services.resume_storage_service - ERROR - Error saving S3 metadata: An error occurred (NoSuchBucket) when calling the PutObject operation: The specified bucket does not exist
+2025-08-20 21:02:36,459 - main - INFO - Loaded .env file for local development
+2025-08-20 21:02:36,468 - botocore.credentials - INFO - Found credentials in shared credentials file: ~/.aws/credentials
+2025-08-20 21:03:13,704 - app.services.resume_storage_service - INFO - [S3] Created new resume with ID: 3d216a61-d55f-4812-8b02-08289a7f22d8
+2025-08-20 21:03:13,790 - app.services.resume_storage_service - INFO - [S3] Retrieved resume data for ID: 3d216a61-d55f-4812-8b02-08289a7f22d8
+2025-08-20 21:03:30,595 - app.services.resume_storage_service - INFO - [S3] Retrieved resume data for ID: 3d216a61-d55f-4812-8b02-08289a7f22d8
+2025-08-20 21:04:48,966 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 21:04:48,967 - main - INFO -   - title_font_size: 12px
+2025-08-20 21:04:48,968 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 21:04:48,968 - main - INFO -   - body_font_size: 12px
+2025-08-20 21:04:48,968 - main - INFO -   - body_font_color: #000000
+2025-08-20 21:04:48,968 - main - INFO -   - line_height: 1.1
+2025-08-20 21:04:48,968 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 21:04:48,968 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': '',
+                   'email': '',
+                   'full_name': 'asd',
+                   'github': '',
+                   'highest_education': '',
+                   'linkedin': '',
+                   'phone': ''},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 21:04:49,089 - app.services.resume_storage_service - INFO - [S3] Retrieved resume data for ID: 3d216a61-d55f-4812-8b02-08289a7f22d8
+2025-08-20 21:04:49,296 - app.services.resume_storage_service - INFO - [S3] Updated resume data for ID: 3d216a61-d55f-4812-8b02-08289a7f22d8
+2025-08-20 21:04:56,614 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 21:04:56,614 - main - INFO -   - title_font_size: 12px
+2025-08-20 21:04:56,614 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 21:04:56,614 - main - INFO -   - body_font_size: 12px
+2025-08-20 21:04:56,614 - main - INFO -   - body_font_color: #000000
+2025-08-20 21:04:56,614 - main - INFO -   - line_height: 1.1
+2025-08-20 21:04:56,614 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 21:04:56,615 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': 'asd',
+                   'email': 'asd',
+                   'full_name': 'asd',
+                   'github': 'asd',
+                   'highest_education': 'asd',
+                   'linkedin': 'asd',
+                   'phone': 'asd'},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': '',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 21:04:56,855 - app.services.resume_storage_service - INFO - [S3] Retrieved resume data for ID: 3d216a61-d55f-4812-8b02-08289a7f22d8
+2025-08-20 21:04:57,188 - app.services.resume_storage_service - INFO - [S3] Updated resume data for ID: 3d216a61-d55f-4812-8b02-08289a7f22d8
+2025-08-20 21:05:03,431 - main - INFO - [DEBUG] Font settings from form_data:
+2025-08-20 21:05:03,432 - main - INFO -   - title_font_size: 12px
+2025-08-20 21:05:03,432 - main - INFO -   - title_font_color: #4C5196
+2025-08-20 21:05:03,432 - main - INFO -   - body_font_size: 12px
+2025-08-20 21:05:03,432 - main - INFO -   - body_font_color: #000000
+2025-08-20 21:05:03,432 - main - INFO -   - line_height: 1.1
+2025-08-20 21:05:03,432 - main - INFO - [DEBUG] Structured data after parsing dynamic form:
+2025-08-20 21:05:03,433 - main - INFO - {'achievements': [],
+ 'certifications': [],
+ 'education': [{'cgpa': 'asd',
+                'institute': 'asd',
+                'qualification': 'asd',
+                'stream': 'asd',
+                'year': 'asd'}],
+ 'extracurricular': [],
+ 'font_settings': {'body_font_color': '#000000',
+                   'body_font_size': '12px',
+                   'line_height': '1.1',
+                   'title_font_color': '#4C5196',
+                   'title_font_size': '12px'},
+ 'internships': [],
+ 'personal_info': {'city': 'asd',
+                   'email': 'asd',
+                   'full_name': 'asd',
+                   'github': 'asd',
+                   'highest_education': 'asd',
+                   'linkedin': 'asd',
+                   'phone': 'asd'},
+ 'positions_of_responsibility': [],
+ 'projects': [],
+ 'publications': [],
+ 'summary': 'asdasd',
+ 'technical_skills': {'database_management': [],
+                      'programming_languages': [],
+                      'tools_and_technologies': [],
+                      'web_technologies': []},
+ 'work_experience': []}
+2025-08-20 21:05:03,556 - app.services.resume_storage_service - INFO - [S3] Retrieved resume data for ID: 3d216a61-d55f-4812-8b02-08289a7f22d8
+2025-08-20 21:05:03,760 - app.services.resume_storage_service - INFO - [S3] Updated resume data for ID: 3d216a61-d55f-4812-8b02-08289a7f22d8
+2025-08-20 21:05:05,574 - app.services.resume_storage_service - INFO - [S3] Retrieved resume data for ID: 3d216a61-d55f-4812-8b02-08289a7f22d8
+2025-08-20 21:05:12,146 - app.services.resume_storage_service - INFO - [S3] Retrieved resume data for ID: 3d216a61-d55f-4812-8b02-08289a7f22d8
+2025-08-20 21:05:22,627 - app.services.resume_storage_service - INFO - [S3] Retrieved resume data for ID: 3d216a61-d55f-4812-8b02-08289a7f22d8
+2025-08-20 21:05:29,319 - app.services.resume_storage_service - INFO - [S3] Retrieved resume data for ID: 3d216a61-d55f-4812-8b02-08289a7f22d8

--- a/app.log
+++ b/app.log
@@ -3379,3 +3379,6 @@ NameError: name 'async_playwright' is not defined
  'work_experience': []}
 2025-08-20 18:35:34,110 - app.services.resume_storage_service - INFO - Retrieved resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
 2025-08-20 18:35:34,111 - app.services.resume_storage_service - INFO - Updated resume data for ID: 3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0
+2025-08-20 20:53:42,978 - main - INFO - Loaded .env file for local development
+2025-08-20 20:53:42,987 - botocore.credentials - INFO - Found credentials in shared credentials file: ~/.aws/credentials
+2025-08-20 20:53:43,188 - app.services.resume_storage_service - ERROR - Error saving S3 metadata: An error occurred (NoSuchBucket) when calling the PutObject operation: The specified bucket does not exist

--- a/app/models/cv_data.py
+++ b/app/models/cv_data.py
@@ -8,77 +8,77 @@ from datetime import datetime
 
 class PersonalInfo(BaseModel):
     """Personal information section of CV"""
-    full_name: str = Field(default="—", min_length=1, max_length=100)
-    highest_education: str = Field(default="—", min_length=1, max_length=100)
-    city: str = Field(default="—", min_length=1, max_length=100)
-    phone: str = Field(default="—", min_length=1, max_length=20)
-    email: str = Field(default="notfilled@email.com")
+    full_name: str = Field(default="", max_length=100)
+    highest_education: str = Field(default="", max_length=100)  
+    city: str = Field(default="", max_length=100)
+    phone: str = Field(default="", max_length=20)
+    email: str = Field(default="")
     github: Optional[str] = Field(None, max_length=100)
     linkedin: Optional[str] = Field(None, max_length=100)
 
 
 class EducationEntry(BaseModel):
     """Single education entry"""
-    qualification: str = Field(default="—", min_length=1, max_length=100)
-    stream: str = Field(default="—", min_length=1, max_length=100)
-    institute: str = Field(default="—", min_length=1, max_length=200)
-    year: str = Field(default="—", min_length=1, max_length=10)
-    cgpa: str = Field(default="—", min_length=1, max_length=10)
+    qualification: str = Field(default="", max_length=100)
+    stream: str = Field(default="", max_length=100)
+    institute: str = Field(default="", max_length=200)
+    year: str = Field(default="", max_length=10)
+    cgpa: str = Field(default="", max_length=10)
 
     @validator('qualification', 'stream', 'institute', 'year', 'cgpa')
     def validate_not_empty(cls, v):
-        if not v or not v.strip():
-            return "—"
+        if not v:
+            return ""
         return v.strip()
 
 
 class AchievementEntry(BaseModel):
     """Single achievement entry"""
-    description: str = Field(default="—", min_length=1, max_length=500)
-    year: str = Field(default="—", min_length=1, max_length=10)
+    description: str = Field(default="", max_length=500)
+    year: str = Field(default="", max_length=10)
 
     @validator('description', 'year')
     def validate_not_empty(cls, v):
         if not v or not v.strip():
-            return "—"
+            return ""
         return v.strip()
 
 
 class CertificationEntry(BaseModel):
     """Single certification entry"""
-    description: str = Field(default="—", min_length=1, max_length=500)
-    year: str = Field(default="—", min_length=1, max_length=10)
+    description: str = Field(default="", max_length=500)
+    year: str = Field(default="", max_length=10)
 
     @validator('description', 'year')
     def validate_not_empty(cls, v):
         if not v or not v.strip():
-            return "—"
+            return ""
         return v.strip()
 
 
 class PublicationEntry(BaseModel):
     """Single publication entry"""
-    description: str = Field(default="—", min_length=1, max_length=500)
-    year: str = Field(default="—", min_length=1, max_length=10)
+    description: str = Field(default="", max_length=500)
+    year: str = Field(default="", max_length=10)
 
     @validator('description', 'year')
     def validate_not_empty(cls, v):
         if not v or not v.strip():
-            return "—"
+            return ""
         return v.strip()
 
 
 class InternshipEntry(BaseModel):
     """Single internship entry"""
-    company: str = Field(default="—", min_length=1, max_length=100)
-    role: str = Field(default="—", min_length=1, max_length=100)
-    duration: str = Field(default="—", min_length=1, max_length=50)
+    company: str = Field(default="", max_length=100)
+    role: str = Field(default="", max_length=100)
+    duration: str = Field(default="", max_length=50)
     points: List[str] = Field(default_factory=list, max_items=5)
 
     @validator('company', 'role', 'duration')
     def validate_not_empty(cls, v):
         if not v or not v.strip():
-            return "—"
+            return ""
         return v.strip()
 
     @validator('points')
@@ -90,15 +90,15 @@ class InternshipEntry(BaseModel):
 
 class WorkExperienceEntry(BaseModel):
     """Single work experience entry"""
-    company: str = Field(default="—", min_length=1, max_length=100)
-    position: str = Field(default="—", min_length=1, max_length=100)
-    duration: str = Field(default="—", min_length=1, max_length=50)
+    company: str = Field(default="", max_length=100)
+    position: str = Field(default="", max_length=100)
+    duration: str = Field(default="", max_length=50)
     points: List[str] = Field(default_factory=list, max_items=5)
 
     @validator('company', 'position', 'duration')
     def validate_not_empty(cls, v):
         if not v or not v.strip():
-            return "—"
+            return ""
         return v.strip()
 
     @validator('points')
@@ -110,16 +110,16 @@ class WorkExperienceEntry(BaseModel):
 
 class ProjectEntry(BaseModel):
     """Single project entry"""
-    title: str = Field(default="—", min_length=1, max_length=100)
-    type: str = Field(default="—", min_length=1, max_length=50)
-    duration: str = Field(default="—", min_length=1, max_length=50)
+    title: str = Field(default="", max_length=100)
+    type: str = Field(default="", max_length=50)
+    duration: str = Field(default="", max_length=50)
     repo_link: Optional[str] = Field(None, max_length=200)
     points: List[str] = Field(default_factory=list, max_items=5)
 
     @validator('title', 'type', 'duration')
     def validate_not_empty(cls, v):
         if not v or not v.strip():
-            return "—"
+            return ""
         return v.strip()
 
     @validator('points')
@@ -131,15 +131,15 @@ class ProjectEntry(BaseModel):
 
 class PositionEntry(BaseModel):
     """Single position of responsibility entry"""
-    club: str = Field(default="—", min_length=1, max_length=100)
-    role: str = Field(default="—", min_length=1, max_length=100)
-    duration: str = Field(default="—", min_length=1, max_length=50)
+    club: str = Field(default="", max_length=100)
+    role: str = Field(default="", max_length=100)
+    duration: str = Field(default="", max_length=50)
     points: List[str] = Field(default_factory=list, max_items=5)
 
     @validator('club', 'role', 'duration')
     def validate_not_empty(cls, v):
         if not v or not v.strip():
-            return "—"
+            return ""
         return v.strip()
 
     @validator('points')
@@ -241,11 +241,11 @@ class CVDocument(BaseModel):
 class CVGenerateRequest(BaseModel):
     """Request model for CV generation from form data"""
     # Personal Information
-    full_name: str = Field(default="—", min_length=1, max_length=100)
-    highest_education: str = Field(default="—", min_length=1, max_length=100)
-    city: str = Field(default="—", min_length=1, max_length=100)
-    phone: str = Field(default="—", min_length=1, max_length=20)
-    email: str = Field(default="notfilled@email.com")
+    full_name: str = Field(default="", max_length=100)
+    highest_education: str = Field(default="", max_length=100)
+    city: str = Field(default="", max_length=100)
+    phone: str = Field(default="", max_length=20)
+    email: str = Field(default="")
     github: Optional[str] = Field(None, max_length=100)
     linkedin: Optional[str] = Field(None, max_length=100)
     

--- a/app/services/resume_storage_service.py
+++ b/app/services/resume_storage_service.py
@@ -61,9 +61,10 @@ class ResumeStorageService:
         """Get the file path for a specific resume"""
         return self.storage_dir / f"{resume_id}.json"
     
-    def create_new_resume(self, initial_data: Optional[Dict[str, Any]] = None) -> str:
-        """Create a new resume with a unique UUID"""
-        resume_id = str(uuid.uuid4())
+    def create_new_resume(self, initial_data: Optional[Dict[str, Any]] = None, resume_id: Optional[str] = None) -> str:
+        """Create a new resume with a unique UUID or a provided one"""
+        if not resume_id:
+            resume_id = str(uuid.uuid4())
         
         # Create resume data structure
         resume_data = {

--- a/app/services/resume_storage_service.py
+++ b/app/services/resume_storage_service.py
@@ -1,6 +1,6 @@
 """
 Resume Storage Service for managing UUID-based resume persistence
-Supports both local storage and future S3 integration
+Supports both local storage and S3-backed storage
 """
 import json
 import os
@@ -9,6 +9,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional, Dict, Any
 from app.core.logging import get_logger
+from botocore.exceptions import ClientError
+from botocore.config import Config as BotoConfig
+import boto3
 
 logger = get_logger(__name__)
 
@@ -222,9 +225,225 @@ def create_resume_storage_service(base_path: Path, storage_type: str = "local") 
     if storage_type == "local":
         return ResumeStorageService(base_path, "local")
     elif storage_type == "s3":
-        # Future S3 implementation
-        raise NotImplementedError("S3 storage not yet implemented")
+        # Construct S3-backed implementation using environment variables
+        bucket_name = os.getenv("S3_BUCKET_NAME")
+        if not bucket_name:
+            raise ValueError("S3_BUCKET_NAME environment variable is required for S3 storage")
+        prefix = os.getenv("S3_PREFIX", "")
+        region = os.getenv("AWS_REGION")
+        return S3ResumeStorageService(bucket_name=bucket_name, prefix=prefix, region=region)
     else:
         raise ValueError(f"Unsupported storage type: {storage_type}")
 
+
+
+class S3ResumeStorageService:
+    """S3-backed storage for resume drafts with UUID-based persistence"""
+    def __init__(self, bucket_name: str, prefix: str = "", region: Optional[str] = None):
+        self.bucket_name = bucket_name
+        # Normalize prefix to either empty or end with '/'
+        if prefix and not prefix.endswith('/'):
+            prefix = prefix + '/'
+        self.prefix = prefix
+        self.metadata_key = f"{self.prefix}metadata/resume_metadata.json"
+        self.s3 = boto3.client(
+            "s3",
+            region_name=region,
+            config=BotoConfig(
+                retries={"max_attempts": 10, "mode": "adaptive"},
+                connect_timeout=5,
+                read_timeout=20
+            )
+        )
+        # Ensure metadata exists
+        self._ensure_metadata()
+
+    def _resume_key(self, resume_id: str) -> str:
+        return f"{self.prefix}resumes/{resume_id}.json"
+
+    def _ensure_metadata(self):
+        try:
+            self.s3.head_object(Bucket=self.bucket_name, Key=self.metadata_key)
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code")
+            if error_code in ("404", "NoSuchKey", "NotFound"):
+                initial_metadata = {
+                    "version": "1.0",
+                    "created_at": datetime.now().isoformat(),
+                    "resumes": {}
+                }
+                self._save_metadata(initial_metadata)
+            else:
+                raise
+
+    def _load_metadata(self) -> Dict[str, Any]:
+        try:
+            obj = self.s3.get_object(Bucket=self.bucket_name, Key=self.metadata_key)
+            body = obj["Body"].read()
+            return json.loads(body.decode("utf-8"))
+        except ClientError as e:
+            logger.warning(f"Error loading S3 metadata: {e}")
+            # Reinitialize and return empty structure
+            initial_metadata = {
+                "version": "1.0",
+                "created_at": datetime.now().isoformat(),
+                "resumes": {}
+            }
+            self._save_metadata(initial_metadata)
+            return initial_metadata
+        except Exception as e:
+            logger.error(f"Unexpected error reading S3 metadata: {e}")
+            raise
+
+    def _save_metadata(self, metadata: Dict[str, Any]):
+        try:
+            body = json.dumps(metadata, indent=2, ensure_ascii=False).encode("utf-8")
+            self.s3.put_object(
+                Bucket=self.bucket_name,
+                Key=self.metadata_key,
+                Body=body,
+                ContentType="application/json"
+            )
+        except Exception as e:
+            logger.error(f"Error saving S3 metadata: {e}")
+            raise
+
+    def create_new_resume(self, initial_data: Optional[Dict[str, Any]] = None, resume_id: Optional[str] = None) -> str:
+        if not resume_id:
+            resume_id = str(uuid.uuid4())
+        resume_data = {
+            "resume_id": resume_id,
+            "created_at": datetime.now().isoformat(),
+            "last_modified": datetime.now().isoformat(),
+            "data": initial_data or {},
+            "is_completed": False
+        }
+        key = self._resume_key(resume_id)
+        try:
+            self.s3.put_object(
+                Bucket=self.bucket_name,
+                Key=key,
+                Body=json.dumps(resume_data, indent=2, ensure_ascii=False).encode("utf-8"),
+                ContentType="application/json"
+            )
+            metadata = self._load_metadata()
+            metadata.setdefault("resumes", {})[resume_id] = {
+                "created_at": resume_data["created_at"],
+                "last_modified": resume_data["last_modified"],
+                "is_completed": resume_data["is_completed"]
+            }
+            self._save_metadata(metadata)
+            logger.info(f"[S3] Created new resume with ID: {resume_id}")
+            return resume_id
+        except Exception as e:
+            logger.error(f"[S3] Error creating resume {resume_id}: {e}")
+            raise
+
+    def get_resume_data(self, resume_id: str) -> Optional[Dict[str, Any]]:
+        key = self._resume_key(resume_id)
+        try:
+            obj = self.s3.get_object(Bucket=self.bucket_name, Key=key)
+            body = obj["Body"].read()
+            data = json.loads(body.decode("utf-8"))
+            logger.info(f"[S3] Retrieved resume data for ID: {resume_id}")
+            return data
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code")
+            if error_code in ("404", "NoSuchKey", "NotFound"):
+                logger.warning(f"[S3] Resume not found: {resume_id}")
+                return None
+            logger.error(f"[S3] Error retrieving resume {resume_id}: {e}")
+            return None
+        except Exception as e:
+            logger.error(f"[S3] Unexpected error retrieving resume {resume_id}: {e}")
+            return None
+
+    def update_resume_data(self, resume_id: str, data: Dict[str, Any], is_completed: bool = False) -> bool:
+        existing = self.get_resume_data(resume_id)
+        if not existing:
+            logger.warning(f"[S3] Cannot update non-existent resume: {resume_id}")
+            return False
+        resume_data = {
+            "resume_id": resume_id,
+            "created_at": existing["created_at"],
+            "last_modified": datetime.now().isoformat(),
+            "data": data,
+            "is_completed": is_completed
+        }
+        key = self._resume_key(resume_id)
+        try:
+            self.s3.put_object(
+                Bucket=self.bucket_name,
+                Key=key,
+                Body=json.dumps(resume_data, indent=2, ensure_ascii=False).encode("utf-8"),
+                ContentType="application/json"
+            )
+            metadata = self._load_metadata()
+            if "resumes" in metadata and resume_id in metadata["resumes"]:
+                metadata["resumes"][resume_id]["last_modified"] = resume_data["last_modified"]
+                metadata["resumes"][resume_id]["is_completed"] = is_completed
+                self._save_metadata(metadata)
+            logger.info(f"[S3] Updated resume data for ID: {resume_id}")
+            return True
+        except Exception as e:
+            logger.error(f"[S3] Error updating resume {resume_id}: {e}")
+            return False
+
+    def resume_exists(self, resume_id: str) -> bool:
+        key = self._resume_key(resume_id)
+        try:
+            self.s3.head_object(Bucket=self.bucket_name, Key=key)
+            return True
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code")
+            if error_code in ("404", "NoSuchKey", "NotFound"):
+                return False
+            logger.error(f"[S3] Error checking existence for {resume_id}: {e}")
+            return False
+        except Exception as e:
+            logger.error(f"[S3] Unexpected error checking existence for {resume_id}: {e}")
+            return False
+
+    def delete_resume(self, resume_id: str) -> bool:
+        key = self._resume_key(resume_id)
+        try:
+            self.s3.delete_object(Bucket=self.bucket_name, Key=key)
+            metadata = self._load_metadata()
+            if "resumes" in metadata and resume_id in metadata["resumes"]:
+                del metadata["resumes"][resume_id]
+                self._save_metadata(metadata)
+            logger.info(f"[S3] Deleted resume with ID: {resume_id}")
+            return True
+        except Exception as e:
+            logger.error(f"[S3] Error deleting resume {resume_id}: {e}")
+            return False
+
+    def list_resumes(self) -> Dict[str, Any]:
+        try:
+            metadata = self._load_metadata()
+            return metadata
+        except Exception as e:
+            logger.error(f"[S3] Error listing resumes: {e}")
+            return {"resumes": {}, "version": "1.0"}
+
+    def cleanup_old_resumes(self, days_old: int = 30) -> int:
+        try:
+            from datetime import timedelta
+            cutoff_date = datetime.now() - timedelta(days=days_old)
+            cleaned = 0
+            metadata = self._load_metadata()
+            to_remove = []
+            for resume_id, info in metadata.get("resumes", {}).items():
+                if not info.get("is_completed", False):
+                    created_at = datetime.fromisoformat(info["created_at"])
+                    if created_at < cutoff_date:
+                        to_remove.append(resume_id)
+            for resume_id in to_remove:
+                if self.delete_resume(resume_id):
+                    cleaned += 1
+            logger.info(f"[S3] Cleaned up {cleaned} old resumes")
+            return cleaned
+        except Exception as e:
+            logger.error(f"[S3] Error cleaning up old resumes: {e}")
+            return 0
 

--- a/app/services/resume_storage_service.py
+++ b/app/services/resume_storage_service.py
@@ -1,0 +1,229 @@
+"""
+Resume Storage Service for managing UUID-based resume persistence
+Supports both local storage and future S3 integration
+"""
+import json
+import os
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Dict, Any
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class ResumeStorageService:
+    """Service for managing resume data storage with UUID-based persistence"""
+    
+    def __init__(self, base_path: Path, storage_type: str = "local"):
+        self.base_path = base_path
+        self.storage_type = storage_type
+        self.storage_dir = base_path / "resume_data"
+        self.metadata_file = self.storage_dir / "resume_metadata.json"
+        
+        # Ensure storage directory exists
+        self.storage_dir.mkdir(exist_ok=True)
+        
+        # Initialize metadata file if it doesn't exist
+        if not self.metadata_file.exists():
+            self._initialize_metadata()
+    
+    def _initialize_metadata(self):
+        """Initialize the metadata file with empty structure"""
+        initial_metadata = {
+            "version": "1.0",
+            "created_at": datetime.now().isoformat(),
+            "resumes": {}
+        }
+        self._save_metadata(initial_metadata)
+    
+    def _load_metadata(self) -> Dict[str, Any]:
+        """Load metadata from file"""
+        try:
+            with open(self.metadata_file, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            logger.warning(f"Error loading metadata: {e}, initializing new metadata")
+            self._initialize_metadata()
+            return self._load_metadata()
+    
+    def _save_metadata(self, metadata: Dict[str, Any]):
+        """Save metadata to file"""
+        try:
+            with open(self.metadata_file, 'w', encoding='utf-8') as f:
+                json.dump(metadata, f, indent=2, ensure_ascii=False)
+        except Exception as e:
+            logger.error(f"Error saving metadata: {e}")
+            raise
+    
+    def _get_resume_file_path(self, resume_id: str) -> Path:
+        """Get the file path for a specific resume"""
+        return self.storage_dir / f"{resume_id}.json"
+    
+    def create_new_resume(self, initial_data: Optional[Dict[str, Any]] = None) -> str:
+        """Create a new resume with a unique UUID"""
+        resume_id = str(uuid.uuid4())
+        
+        # Create resume data structure
+        resume_data = {
+            "resume_id": resume_id,
+            "created_at": datetime.now().isoformat(),
+            "last_modified": datetime.now().isoformat(),
+            "data": initial_data or {},
+            "is_completed": False
+        }
+        
+        # Save resume data
+        self._save_resume_data(resume_id, resume_data)
+        
+        # Update metadata
+        metadata = self._load_metadata()
+        metadata["resumes"][resume_id] = {
+            "created_at": resume_data["created_at"],
+            "last_modified": resume_data["last_modified"],
+            "is_completed": resume_data["is_completed"]
+        }
+        self._save_metadata(metadata)
+        
+        logger.info(f"Created new resume with ID: {resume_id}")
+        return resume_id
+    
+    def get_resume_data(self, resume_id: str) -> Optional[Dict[str, Any]]:
+        """Get resume data by UUID"""
+        try:
+            resume_file = self._get_resume_file_path(resume_id)
+            if not resume_file.exists():
+                logger.warning(f"Resume file not found for ID: {resume_id}")
+                return None
+            
+            with open(resume_file, 'r', encoding='utf-8') as f:
+                resume_data = json.load(f)
+            
+            logger.info(f"Retrieved resume data for ID: {resume_id}")
+            return resume_data
+            
+        except Exception as e:
+            logger.error(f"Error retrieving resume data for ID {resume_id}: {e}")
+            return None
+    
+    def update_resume_data(self, resume_id: str, data: Dict[str, Any], is_completed: bool = False) -> bool:
+        """Update existing resume data"""
+        try:
+            # Load existing data
+            existing_data = self.get_resume_data(resume_id)
+            if not existing_data:
+                logger.warning(f"Cannot update non-existent resume: {resume_id}")
+                return False
+            
+            # Update resume data
+            resume_data = {
+                "resume_id": resume_id,
+                "created_at": existing_data["created_at"],
+                "last_modified": datetime.now().isoformat(),
+                "data": data,
+                "is_completed": is_completed
+            }
+            
+            # Save updated data
+            self._save_resume_data(resume_id, resume_data)
+            
+            # Update metadata
+            metadata = self._load_metadata()
+            if resume_id in metadata["resumes"]:
+                metadata["resumes"][resume_id]["last_modified"] = resume_data["last_modified"]
+                metadata["resumes"][resume_id]["is_completed"] = is_completed
+                self._save_metadata(metadata)
+            
+            logger.info(f"Updated resume data for ID: {resume_id}")
+            return True
+            
+        except Exception as e:
+            logger.error(f"Error updating resume data for ID {resume_id}: {e}")
+            return False
+    
+    def _save_resume_data(self, resume_id: str, resume_data: Dict[str, Any]):
+        """Save resume data to file"""
+        try:
+            resume_file = self._get_resume_file_path(resume_id)
+            with open(resume_file, 'w', encoding='utf-8') as f:
+                json.dump(resume_data, f, indent=2, ensure_ascii=False)
+        except Exception as e:
+            logger.error(f"Error saving resume data for ID {resume_id}: {e}")
+            raise
+    
+    def resume_exists(self, resume_id: str) -> bool:
+        """Check if a resume exists"""
+        resume_file = self._get_resume_file_path(resume_id)
+        return resume_file.exists()
+    
+    def delete_resume(self, resume_id: str) -> bool:
+        """Delete a resume and its data"""
+        try:
+            # Remove resume file
+            resume_file = self._get_resume_file_path(resume_id)
+            if resume_file.exists():
+                resume_file.unlink()
+            
+            # Update metadata
+            metadata = self._load_metadata()
+            if resume_id in metadata["resumes"]:
+                del metadata["resumes"][resume_id]
+                self._save_metadata(metadata)
+            
+            logger.info(f"Deleted resume with ID: {resume_id}")
+            return True
+            
+        except Exception as e:
+            logger.error(f"Error deleting resume with ID {resume_id}: {e}")
+            return False
+    
+    def list_resumes(self) -> Dict[str, Any]:
+        """List all resumes with metadata"""
+        try:
+            metadata = self._load_metadata()
+            return metadata
+        except Exception as e:
+            logger.error(f"Error listing resumes: {e}")
+            return {"resumes": {}, "version": "1.0"}
+    
+    def cleanup_old_resumes(self, days_old: int = 30) -> int:
+        """Clean up old incomplete resumes"""
+        try:
+            from datetime import timedelta
+            cutoff_date = datetime.now() - timedelta(days=days_old)
+            cleaned_count = 0
+            
+            metadata = self._load_metadata()
+            resumes_to_remove = []
+            
+            for resume_id, resume_info in metadata["resumes"].items():
+                if not resume_info.get("is_completed", False):
+                    created_at = datetime.fromisoformat(resume_info["created_at"])
+                    if created_at < cutoff_date:
+                        resumes_to_remove.append(resume_id)
+            
+            for resume_id in resumes_to_remove:
+                if self.delete_resume(resume_id):
+                    cleaned_count += 1
+            
+            logger.info(f"Cleaned up {cleaned_count} old resumes")
+            return cleaned_count
+            
+        except Exception as e:
+            logger.error(f"Error cleaning up old resumes: {e}")
+            return 0
+
+
+# Factory function for creating storage service
+def create_resume_storage_service(base_path: Path, storage_type: str = "local") -> ResumeStorageService:
+    """Create a resume storage service instance"""
+    if storage_type == "local":
+        return ResumeStorageService(base_path, "local")
+    elif storage_type == "s3":
+        # Future S3 implementation
+        raise NotImplementedError("S3 storage not yet implemented")
+    else:
+        raise ValueError(f"Unsupported storage type: {storage_type}")
+
+

--- a/context_for_ai/infra.md
+++ b/context_for_ai/infra.md
@@ -21,7 +21,7 @@ Internet
     ▼
 [EC2 Instance] ─── Ubuntu 22.04 LTS (t3.small)
     │
-    ├── [Nginx] ─── Reverse Proxy (Port 80 → 8000)
+    ├── [Nginx] ─── HTTP→HTTPS redirect; Reverse Proxy (Port 443 → 8000)
     │
     └── [FastAPI App] ─── CV Generator Application (Port 8000)
 ```
@@ -40,6 +40,10 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "~> 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
   required_version = ">= 1.0"
 }
@@ -48,6 +52,22 @@ terraform {
 ### **Provider Setup**
 - **AWS Provider**: Configured with region variable (default: ap-south-1)
 - **Cloudflare Provider**: Configured with email and API key for DNS management
+
+### **Remote Backend (Terraform State)**
+- **S3 Backend**: Remote state stored in an S3 bucket with server-side encryption
+- **DynamoDB Locking**: State locking via DynamoDB table
+- The Terraform configuration uses a remote backend in the `terraform` block. Supporting resources are provisioned in `terraform/backend.tf` (S3 bucket with versioning and DynamoDB lock table).
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "cv-generator-terraform-state-moh8l579"
+    key            = "terraform.tfstate"
+    region         = "ap-south-1"
+    dynamodb_table = "cv-generator-terraform-locks"
+    encrypt        = true
+  }
+}
+```
 
 ## **Variables Configuration**
 
@@ -62,7 +82,7 @@ terraform {
 ### **Application Variables**
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `repo_url` | string | "https://github.com/..." | Git repository URL to clone |
+| `repo_url` | string | "https://github.com/your-username/cv-generator.git" | Git repository URL to clone |
 
 ### **Cloudflare Variables**
 | Variable | Type | Default | Description |
@@ -216,12 +236,12 @@ certbot --nginx -d ${domain} --non-interactive --agree-tos --email admin@${domai
 ```
 
 ### **Certificate Management**
-- **Certificate Authority**: Let's Encrypt (R11)
+- **Certificate Authority**: Let's Encrypt
 - **Certificate Path**: `/etc/letsencrypt/live/${domain}/fullchain.pem`
 - **Private Key Path**: `/etc/letsencrypt/live/${domain}/privkey.pem`
 - **Validity**: 90 days with automatic renewal
-- **Auto-Renewal**: systemd timer runs `certbot renew` twice daily
-- **Deployment**: Automatic Nginx configuration with SSL termination
+- **Auto-Renewal**: systemd timer runs `certbot renew` (enabled via `certbot.timer`)
+- **Deployment**: Automatic Nginx configuration with SSL termination and HTTP→HTTPS redirect
 
 ### **SSL Security Features**
 - **Protocols**: TLS 1.2 and TLS 1.3 only
@@ -330,11 +350,31 @@ EOL
 
 #### **8. Nginx Configuration**
 ```bash
-# Reverse proxy configuration
+# HTTP→HTTPS redirect and HTTPS reverse proxy configuration
 cat > /etc/nginx/sites-available/cv-generator << 'EOL'
 server {
     listen 80;
     server_name ${domain} _;
+
+    # Redirect all HTTP to HTTPS
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name ${domain} _;
+
+    # SSL
+    ssl_certificate /etc/letsencrypt/live/${domain}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${domain}/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    # Security headers
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options DENY always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-XSS-Protection "1; mode=block" always;
 
     client_max_body_size 50M;
 
@@ -364,6 +404,10 @@ EOL
 systemctl daemon-reload
 systemctl enable nginx cv-generator
 systemctl restart nginx cv-generator
+
+# Enable certbot timer for auto-renewal
+systemctl enable certbot.timer
+systemctl start certbot.timer
 
 # Health verification
 systemctl status nginx --no-pager

--- a/context_for_ai/infra.md
+++ b/context_for_ai/infra.md
@@ -24,6 +24,7 @@ Internet
     ├── [Nginx] ─── HTTP→HTTPS redirect; Reverse Proxy (Port 443 → 8000)
     │
     └── [FastAPI App] ─── CV Generator Application (Port 8000)
+         └── [S3 Bucket] ─── Resume draft storage (JSON objects)
 ```
 
 ## **Provider Configuration**
@@ -83,6 +84,8 @@ terraform {
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | `repo_url` | string | "https://github.com/your-username/cv-generator.git" | Git repository URL to clone |
+| `app_s3_bucket_name` | string | (required) | S3 bucket for resume drafts |
+| `app_s3_prefix` | string | "" | Optional S3 key prefix (e.g., `prod/`) |
 
 ### **Cloudflare Variables**
 | Variable | Type | Default | Description |
@@ -168,8 +171,7 @@ resource "aws_iam_role" "ec2_role" {
 
 ### **Instance Profile**
 - **Purpose**: Allows EC2 instance to assume the IAM role
-- **Future Use**: Ready for AWS service integrations (S3, SES, etc.)
-- **Current Permissions**: Basic EC2 assume role only
+- **Current Permissions**: S3 access for resume storage + EC2 assume role
 
 ## **EC2 Instance Configuration**
 
@@ -192,6 +194,7 @@ resource "aws_iam_role" "ec2_role" {
 - **Logging**: Complete setup process logged to `/var/log/user-data.log`
 - **Idempotent**: Can run multiple times safely without completion markers
 - **SSL Automation**: Automatic Let's Encrypt certificate generation and renewal
+- **Environment Variables**: Injects `RESUME_STORAGE_TYPE=s3`, `S3_BUCKET_NAME`, `S3_PREFIX`, `AWS_REGION` into systemd service
 
 ## **Elastic IP Configuration**
 
@@ -339,6 +342,10 @@ Group=cvapp
 WorkingDirectory=/home/cvapp/app
 Environment=PATH=/home/cvapp/app/venv/bin
 Environment=PYTHONPATH=/home/cvapp/app
+Environment=RESUME_STORAGE_TYPE=s3
+Environment=S3_BUCKET_NAME=${app_s3_bucket_name}
+Environment=S3_PREFIX=${app_s3_prefix}
+Environment=AWS_REGION=${aws_region}
 ExecStart=/home/cvapp/app/venv/bin/uvicorn main:app --host 127.0.0.1 --port 8000 --workers 1
 Restart=always
 RestartSec=3
@@ -459,6 +466,8 @@ EOL
 | `application_url` | HTTPS IP access | `https://13.127.123.456` |
 | `custom_domain_url` | HTTPS custom domain | `https://cv-generator.avantifellows.org` |
 | `http_redirect_url` | HTTP URL that redirects to HTTPS | `http://cv-generator.avantifellows.org` |
+| `app_s3_bucket_name` | Application S3 bucket name | `avantifellows-cv-generator-storage` |
+| `app_s3_bucket_arn` | Application S3 bucket ARN | `arn:aws:s3:::avantifellows-cv-generator-storage` |
 
 ## **Deployment Process**
 
@@ -614,9 +623,10 @@ cat /etc/nginx/sites-available/cv-generator
 - ✅ **Security Headers**: HSTS, XSS protection, and content security
 - ✅ **HTTPS Enforcement**: Automatic HTTP to HTTPS redirects
 - ✅ **Idempotent Deployment**: Safe multi-run user data scripts
+- ✅ **S3-backed Resume Storage**: Private bucket with versioning, SSE, and IAM role access; systemd service configured with S3 env vars
 
 ### **Planned Infrastructure Improvements**
-- **S3 Integration**: Persistent storage for generated CVs
+- **S3 Integration**: Persistent storage for generated CVs (drafts done)
 - **Load Balancer**: Multiple instance support
 - **Auto Scaling**: Dynamic capacity management
 - **CDN**: CloudFront for static asset delivery

--- a/context_for_ai/project_summary.md
+++ b/context_for_ai/project_summary.md
@@ -16,11 +16,12 @@ This is a **professional CV/Resume Generator web application** built with FastAP
 ```
 fastapi==0.104.1
 uvicorn==0.24.0
+python-multipart==0.0.6
+jinja2==3.1.2
+aiofiles==23.2.1
+python-dotenv==1.0.0
 playwright>=1.40.0
 pydantic>=2.11.0
-jinja2==3.1.2
-python-multipart==0.0.6
-aiofiles==23.2.1
 ```
 
 ## **Project Structure**
@@ -28,17 +29,19 @@ aiofiles==23.2.1
 ```
 cv-generator/
 ├── app/
-│   ├── models/cv_data.py         # Pydantic data models
-│   ├── services/cv_service.py    # Business logic layer
-│   └── core/                     # Exceptions, logging
+│   ├── models/cv_data.py                   # Pydantic data models
+│   ├── services/cv_service.py              # Business logic layer
+│   ├── services/resume_storage_service.py  # Resume draft persistence service
+│   └── core/                               # Exceptions, logging
 ├── templates/
-│   ├── form.html                 # Dynamic web form
-│   ├── cv_template.html          # Web display template
-│   └── cv_template_pdf.html      # PDF-optimized template
-├── terraform/                    # AWS deployment infrastructure
-├── main.py                       # FastAPI application entry point
-├── generated/                    # Output directory for CVs
-└── test_data_structured.json     # Sample data
+│   ├── root_choice.html                    # Root landing UI (continue or start new)
+│   ├── form.html                           # Dynamic web form (UUID-aware)
+│   ├── cv_template.html                    # Web display template (view and view-only modes)
+│   └── cv_template_pdf.html                # PDF-optimized template
+├── terraform/                              # AWS deployment infrastructure
+├── main.py                                 # FastAPI application entry point
+├── generated/                              # Output directory for CVs
+└── test_data_structured.json               # Sample data
 ```
 
 ## **Key Features & Capabilities**
@@ -52,6 +55,10 @@ cv-generator/
 ### **2. Dynamic Form System**
 - **Interactive Web Form**: Add/remove sections dynamically
 - **Real-time Preview**: Live CV preview as you type
+- **Auto-save Status Indicator**: Small banner under "Live Preview" that toggles between saved and unsaved states:
+  - Saved: “Changes saved last at HH:MM:SS” with a green checkmark
+  - Unsaved: “Unsaved changes present ... auto saving” with a subtle spinner
+  - Hidden until the user makes their first change
 - **Data Validation**: Client and server-side validation
 - **Test Data Integration**: Pre-filled form for testing
 
@@ -60,12 +67,16 @@ cv-generator/
 - **Smart Rendering**: Conditional sections (only shows filled content)
 - **Professional Styling**: Clean, academic resume format
 - **Optimized PDF**: A4 format with proper margins using Playwright
+- **Font Customization**: End-user controls for heading/body font sizes, colors, and line-height
 
 ### **4. Data Management**
 - **Structured Storage**: JSON format with metadata
 - **UUID-based IDs**: Unique identifiers for each CV
+- **Resume Storage Service**: Drafts stored in `resume_data/` with `resume_metadata.json` tracking
+- **Client-side Persistence (localStorage)**: Stores the most recent `resume_id` to let users continue where they left off; cookies removed for simplicity
 - **Legacy Support**: Backward compatibility with old data formats
 - **Complete Workflow**: Form → Validation → Storage → Rendering → PDF
+- **No Placeholder Defaults**: Empty fields remain empty across parsing, models, and templates (no auto-inserted dashes or dummy emails)
 
 ## **Core Workflow**
 
@@ -73,12 +84,15 @@ cv-generator/
    - Personal Information
    - Professional Summary (optional)
    - Education (multiple entries)
+   - Work Experience
    - Achievements
+   - Certifications
+   - Publications
    - Internships
    - Projects
    - Positions of Responsibility
    - Extracurricular Activities
-   - Technical Skills
+   - Technical Skills (categorized)
 
 2. **Data Processing** → Pydantic validation and structured storage
 3. **Template Rendering** → Jinja2 templates for HTML output
@@ -88,47 +102,58 @@ cv-generator/
 ## **API Endpoints**
 
 ### **Web Interface**
-- `GET /` - Main CV form
+- `GET /` - Root landing UI that lets users continue the last resume (via localStorage) or start a new one; supports `?new=1` to force a fresh resume and `?resume_id={id}` to open a specific resume
+- `GET /resume/` - Redirects to `/` to avoid 404 when missing an ID
+- `GET /resume/{resume_id}` - Edit form for that resume (draft-aware)
+- `POST /resume/{resume_id}/save` - Save draft data
+- `GET /resume/{resume_id}/view` - View-only mode for sharing
+- `GET /resume/{resume_id}/share` - Returns shareable link JSON
 - `GET /test` - Pre-filled test form
-- `POST /generate` - Generate CV from form data
-- `GET /cv/{cv_id}` - View CV with download button
-- `GET /cv/{cv_id}/pdf` - Download PDF
+- `POST /generate` - Generate CV from form data (supports legacy and dynamic formats; can direct-download PDF)
+- `GET /cv/{cv_id}` - View generated CV with download button
+- `GET /cv/{cv_id}/html` - Raw HTML CV
+- `GET /cv/{cv_id}/pdf` - On-demand PDF generation via Playwright
 
 ### **API Endpoints**
 - `GET /api/v1/cvs` - List all CVs
 - `GET /api/v1/cv/{cv_id}` - Get CV data
 - `DELETE /api/v1/cv/{cv_id}` - Delete CV
-- `GET /health` - Health check
 
 ## **Deployment Infrastructure**
 
 ### **AWS EC2 Deployment**
-- **Terraform Configuration**: Infrastructure as Code
+- **Terraform Configuration**: Infrastructure as Code with remote backend (S3 + DynamoDB locking)
 - **EC2 Instance**: t3.small Ubuntu 22.04 LTS
-- **Nginx Reverse Proxy**: HTTP traffic routing with SSL termination
+- **Nginx Reverse Proxy**: HTTPS termination and HTTP→HTTPS redirect; reverse proxy to 127.0.0.1:8000
 - **SystemD Service**: Application lifecycle management
 - **Cloudflare DNS**: Custom domain management
-- **SSL/TLS**: Let's Encrypt certificates with automatic renewal
+- **SSL/TLS**: Let's Encrypt certificates with automatic renewal (certbot.timer)
 - **Automated Setup**: Complete deployment with idempotent user data scripts
 
 ### **Key Infrastructure Components**
 - **Security Group**: SSH (22), HTTP (80), HTTPS (443), FastAPI (8000)
 - **Elastic IP**: Static IP address for the instance
 - **IAM Role**: EC2 instance profile for future AWS services
+- **Remote Backend**: S3 state bucket with versioning + DynamoDB lock table
 - **User Data Script**: Idempotent application setup on instance launch
 - **SSL Certificate**: Automated Let's Encrypt certificate management
 - **Security Headers**: HSTS, X-Frame-Options, XSS protection
 
 ## **Recent Technical Improvements**
 
+- ✅ **UUID-based Resume Flow**: Create/edit/view via `/resume/{resume_id}` with shareable view-only link
+- ✅ **Resume Storage Service**: Draft persistence in `resume_data/` with metadata tracking
 - ✅ **PDF Library Migration**: Playwright for better quality (from xhtml2pdf)
 - ✅ **Professional Summary**: Added optional summary section
 - ✅ **Template Optimization**: Improved formatting and spacing
 - ✅ **Dynamic Content**: Smart conditional rendering
+- ✅ **Font Customization**: Title/body font sizes/colors and line-height
 - ✅ **Clean Architecture**: Service layer and Pydantic models
 - ✅ **SSL/HTTPS Implementation**: Let's Encrypt certificates with automatic renewal
 - ✅ **Idempotent Deployment**: Safe multi-run user data scripts
 - ✅ **Security Headers**: HSTS, XSS protection, content security policies
+- ✅ **Save-status UI**: Added saved/unsaved banner with timestamp, checkmark, and spinner under “Live Preview”
+- ✅ **Removed Placeholder Dashes**: Eliminated auto-insertion of “—”/dummy email; models now default to empty strings and parsers preserve empties
 
 ## **Current Development Status**
 
@@ -139,11 +164,12 @@ cv-generator/
 - Professional template design
 - AWS deployment infrastructure
 - Comprehensive error handling and logging
+- UUID-based resume creation/editing and view-only sharing
+- Resume drafts persisted via `ResumeStorageService` in `resume_data/`
 
 ### **Planned Enhancements** (from TODOs)
-- AWS S3 integration for persistent storage
+- AWS S3 integration for persistent storage of generated CVs and drafts
 - Search functionality for generated CVs
-- Resume editing capabilities
 - Enhanced user management
 
 ## **Data Structure Example**
@@ -165,9 +191,10 @@ The application uses structured JSON format:
 ## **Template System**
 
 ### **Template Files**
-- `cv_template.html` - Web display with embedded CSS and interactive features
-- `cv_template_pdf.html` - PDF-optimized with specific styling for print
-- `form.html` - Dynamic form with JavaScript for adding/removing sections
+- `root_choice.html` - Minimal root landing UI to continue or start new using localStorage
+- `cv_template.html` - Web display with embedded CSS; supports view-only mode and font settings
+- `cv_template_pdf.html` - PDF-optimized with specific styling for print and font settings
+- `form.html` - Dynamic, UUID-aware form with JavaScript for adding/removing sections and draft-saving
 
 ### **Template Features**
 - **Conditional Rendering**: Only shows sections with actual content
@@ -185,15 +212,33 @@ The application uses structured JSON format:
 - `list_cvs()` - Get all CVs with metadata
 - `convert_legacy_data(form_data)` - Backward compatibility
 
+### **ResumeStorageService** (`app/services/resume_storage_service.py`)
+- `create_new_resume(initial_data=None, resume_id=None)` - Returns a new `resume_id`; optionally accepts a pre-defined `resume_id`
+- `get_resume_data(resume_id)` - Retrieve draft data and status
+- `update_resume_data(resume_id, data, is_completed=False)` - Save draft or mark completed
+- `resume_exists(resume_id)` - Check for existence
+- `list_resumes()` - List metadata from `resume_metadata.json`
+- `delete_resume(resume_id)` - Remove draft and clean metadata
+
 ### **Data Models** (`app/models/cv_data.py`)
 - `PersonalInfo` - Name, contact details, education
 - `EducationEntry` - Qualification, institute, year, CGPA
 - `AchievementEntry` - Description and year
+- `CertificationEntry` - Description and year
+- `PublicationEntry` - Description and year
 - `InternshipEntry` - Company, role, duration, points
+- `WorkExperienceEntry` - Company, position, duration, points
 - `ProjectEntry` - Title, type, duration, points
 - `PositionEntry` - Club, role, duration, points
+- `TechnicalSkillsCategory` - Categorized skills (languages, web, DB, tools)
+- `FontSettings` - Title/body sizes, colors, line-height
 - `CVData` - Complete CV structure with validation
 - `CVDocument` - CV data with metadata
+  
+  Model defaults and validation:
+  - Fields default to empty strings instead of placeholder symbols
+  - Validators trim whitespace but do not force placeholder values
+  - Rendering logic only displays fields with actual content
 
 ## **Error Handling & Logging**
 
@@ -303,10 +348,13 @@ sudo systemctl restart cv-generator
 - A4 format with optimized margins
 - Handles complex CSS layouts correctly
 - Supports background colors and modern styling
+- Honors user font settings (sizes, colors, line-height)
 
 ### **Form Handling**
 - Dynamic JavaScript for adding/removing sections
 - Real-time preview with live updates
+- Auto-save with visual status (saved/unsaved) and last-saved timestamp
+- UUID-based routing and draft save via `/resume/{resume_id}/save`
 - Supports both legacy flat format and new structured format
 - Comprehensive client-side validation
 

--- a/context_for_ai/project_summary.md
+++ b/context_for_ai/project_summary.md
@@ -24,6 +24,11 @@ playwright>=1.40.0
 pydantic>=2.11.0
 ```
 
+Additional production dependency:
+```
+boto3>=1.34.0
+```
+
 ## **Project Structure**
 
 ```
@@ -72,7 +77,7 @@ cv-generator/
 ### **4. Data Management**
 - **Structured Storage**: JSON format with metadata
 - **UUID-based IDs**: Unique identifiers for each CV
-- **Resume Storage Service**: Drafts stored in `resume_data/` with `resume_metadata.json` tracking
+- **Resume Storage Service**: S3-backed drafts in production; local JSON files in `resume_data/` for development. Metadata tracked via `metadata/resume_metadata.json` object in S3 (best-effort cache)
 - **Client-side Persistence (localStorage)**: Stores the most recent `resume_id` to let users continue where they left off; cookies removed for simplicity
 - **Legacy Support**: Backward compatibility with old data formats
 - **Complete Workflow**: Form → Validation → Storage → Rendering → PDF
@@ -154,6 +159,7 @@ cv-generator/
 - ✅ **Security Headers**: HSTS, XSS protection, content security policies
 - ✅ **Save-status UI**: Added saved/unsaved banner with timestamp, checkmark, and spinner under “Live Preview”
 - ✅ **Removed Placeholder Dashes**: Eliminated auto-insertion of “—”/dummy email; models now default to empty strings and parsers preserve empties
+- ✅ **S3-backed Resume Storage**: Draft persistence moved to S3 in production with environment-based switching; Terraform-managed bucket, encryption, and IAM
 
 ## **Current Development Status**
 
@@ -165,7 +171,7 @@ cv-generator/
 - AWS deployment infrastructure
 - Comprehensive error handling and logging
 - UUID-based resume creation/editing and view-only sharing
-- Resume drafts persisted via `ResumeStorageService` in `resume_data/`
+- Resume drafts persisted via `ResumeStorageService` (S3 in production; local in development)
 
 ### **Planned Enhancements** (from TODOs)
 - AWS S3 integration for persistent storage of generated CVs and drafts

--- a/env.example
+++ b/env.example
@@ -1,0 +1,19 @@
+# Example .env file for local S3 testing
+# Copy this to .env and update with your values
+
+# Storage type - set to "s3" to test S3 locally, or omit/set to "local" for local files
+RESUME_STORAGE_TYPE=s3
+
+# S3 Configuration (required when RESUME_STORAGE_TYPE=s3)
+S3_BUCKET_NAME=your-test-bucket-name-here
+S3_PREFIX=dev/
+AWS_REGION=ap-south-1
+
+# AWS Credentials (if not using AWS CLI profile)
+# Uncomment and set these if you don't have AWS CLI configured
+# AWS_ACCESS_KEY_ID=your-access-key-here
+# AWS_SECRET_ACCESS_KEY=your-secret-key-here
+
+# Note: On the production server, these environment variables are 
+# automatically set by the systemd service via Terraform user_data.sh
+# No .env file should exist on the server.

--- a/localStorage_enhancement_review.md
+++ b/localStorage_enhancement_review.md
@@ -1,0 +1,145 @@
+# localStorage Enhancement Review for UUID Feature
+
+## 💡 **Enhancement Suggestion: Add localStorage for UUID Persistence**
+
+Great work on implementing the UUID-based resume feature! This is a solid foundation with excellent sharing capabilities. I have a suggestion to significantly improve the user experience by implementing localStorage for UUID persistence.
+
+### **🔍 Current Behavior Analysis**
+
+**✅ What works well:**
+- UUID generation and server-side storage
+- Auto-save functionality every 2 seconds  
+- Clean URL-based sharing (`/resume/{uuid}/view`)
+- Proper separation of edit vs view modes
+
+**⚠️ User Experience Gap:**
+- User visits `/` → always gets redirected to new UUID
+- No "continue where you left off" functionality
+- Users must manually bookmark/copy URLs
+- No history of recent resumes
+
+### **💡 Proposed Enhancement: Smart UUID Persistence**
+
+Store the most recent resume UUID in localStorage so users can automatically continue their last work session.
+
+### **🛠️ Implementation Suggestion**
+
+**1. Modify JavaScript in `templates/form.html`:**
+
+```javascript
+// Add after line 955 where currentResumeId is defined
+function saveToLocalStorage(resumeId) {
+    try {
+        localStorage.setItem('lastResumeId', resumeId);
+        localStorage.setItem('lastResumeTimestamp', Date.now());
+    } catch (e) {
+        console.warn('localStorage not available:', e);
+    }
+}
+
+function getLastResumeFromStorage() {
+    try {
+        const lastId = localStorage.getItem('lastResumeId');
+        const timestamp = localStorage.getItem('lastResumeTimestamp');
+        
+        // Only return if less than 7 days old
+        if (lastId && timestamp && (Date.now() - timestamp < 7 * 24 * 60 * 60 * 1000)) {
+            return lastId;
+        }
+    } catch (e) {
+        console.warn('localStorage not available:', e);
+    }
+    return null;
+}
+
+// Save current resume ID when initialized
+if (currentResumeId) {
+    saveToLocalStorage(currentResumeId);
+}
+```
+
+**2. Modify home endpoint in `main.py`:**
+
+```python
+@app.get("/", response_class=HTMLResponse)
+async def home(request: Request):
+    """Serve CV form - continue last resume or create new"""
+    
+    # Add a check for ?resume_id= parameter from localStorage redirect
+    resume_id = request.query_params.get('resume_id')
+    
+    if resume_id and resume_storage_service.resume_exists(resume_id):
+        # Continue existing resume
+        return RedirectResponse(url=f"/resume/{resume_id}", status_code=302)
+    else:
+        # Create new resume
+        new_resume_id = resume_storage_service.create_new_resume()
+        return RedirectResponse(url=f"/resume/{new_resume_id}", status_code=302)
+```
+
+**3. Add localStorage check on page load:**
+
+```javascript
+// Add to DOMContentLoaded event (around line 2539)
+document.addEventListener('DOMContentLoaded', function() {
+    // Check if we're on the root path and have a stored resume
+    if (window.location.pathname === '/') {
+        const lastResumeId = getLastResumeFromStorage();
+        if (lastResumeId) {
+            // Redirect to continue last resume
+            window.location.href = `/?resume_id=${lastResumeId}`;
+            return;
+        }
+    }
+    
+    // Rest of existing DOMContentLoaded code...
+    updateFontSettingsInputs();
+    if (currentResumeId) {
+        initializeAutoSave();
+        showResumeInfo();
+        saveToLocalStorage(currentResumeId); // Save current resume
+    }
+});
+```
+
+### **🎯 Enhanced User Experience**
+
+**Before:**
+1. User visits `/` → new UUID every time
+2. User must manually save URLs
+3. No resume history
+
+**After:**
+1. User visits `/` → continues last resume (if recent)
+2. Automatic "resume where you left off" 
+3. Optional: Add "Start New Resume" button for explicit new creation
+
+### **🔒 Implementation Benefits**
+
+- **✅ Backward Compatible**: Existing URLs still work
+- **✅ Privacy Friendly**: Only stores UUID, not actual resume data
+- **✅ Automatic Cleanup**: 7-day expiry prevents stale data
+- **✅ Graceful Fallback**: Works without localStorage
+- **✅ User Control**: Users can still create new resumes explicitly
+
+### **📱 Optional: Add Resume Management UI**
+
+```javascript
+// Optional: Show recent resume option
+function showResumeOptions() {
+    const lastResumeId = getLastResumeFromStorage();
+    if (lastResumeId && window.location.pathname === '/') {
+        // Show a banner: "Continue last resume or start new?"
+    }
+}
+```
+
+### **🧪 Testing Scenarios**
+
+1. **New User**: Normal flow → new UUID
+2. **Returning User**: Visits `/` → continues last resume  
+3. **Expired Resume**: Old localStorage → creates new UUID
+4. **Manual New Resume**: Add button to force new creation
+5. **localStorage Disabled**: Graceful fallback to current behavior
+
+This enhancement would make the resume builder feel much more like a modern web app where users expect to "pick up where they left off" automatically!

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ from playwright.async_api import async_playwright
 # Import our new models and services
 from app.models.cv_data import CVData, CVGenerateRequest, CVGenerateResponse
 from app.services.cv_service import CVService
+from app.services.resume_storage_service import create_resume_storage_service
 from app.core.exceptions import CVGenerationError, CVNotFoundError, TemplateError, PDFGenerationError
 from app.core.logging import setup_logging, get_logger
 
@@ -50,6 +51,7 @@ templates = Jinja2Templates(directory="templates")
 
 # Initialize services
 cv_service = CVService(base_path=BASE_PATH)
+resume_storage_service = create_resume_storage_service(BASE_PATH, "local")
 
 async def generate_pdf_with_playwright(html_content: str) -> bytes:
     """Generate PDF from HTML using Playwright"""
@@ -114,8 +116,145 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 # API Endpoints
 @app.get("/", response_class=HTMLResponse)
 async def home(request: Request):
-    """Serve the dynamic CV form"""
-    return templates.TemplateResponse("form.html", {"request": request})
+    """Serve the dynamic CV form - creates new resume with UUID"""
+    try:
+        # Create a new resume with UUID
+        resume_id = resume_storage_service.create_new_resume()
+        
+        # Redirect to the UUID-based URL
+        return RedirectResponse(url=f"/resume/{resume_id}", status_code=302)
+        
+    except Exception as e:
+        logger.error(f"Error creating new resume: {str(e)}")
+        # Fall back to empty form
+        return templates.TemplateResponse("form.html", {"request": request})
+
+
+@app.get("/resume/{resume_id}", response_class=HTMLResponse)
+async def resume_form(request: Request, resume_id: str):
+    """Serve the CV form with existing data or create new if not exists"""
+    try:
+        # Check if resume exists
+        if resume_storage_service.resume_exists(resume_id):
+            # Load existing resume data
+            resume_data = resume_storage_service.get_resume_data(resume_id)
+            if resume_data and resume_data.get("data"):
+                # Resume exists with data - show in edit mode
+                return templates.TemplateResponse("form.html", {
+                    "request": request, 
+                    "form_data": resume_data["data"],
+                    "resume_id": resume_id,
+                    "is_edit_mode": True,
+                    "is_completed": resume_data.get("is_completed", False)
+                })
+            else:
+                # Resume exists but no data - show empty form
+                return templates.TemplateResponse("form.html", {
+                    "request": request,
+                    "resume_id": resume_id,
+                    "is_edit_mode": False,
+                    "is_completed": False
+                })
+        else:
+            # Resume doesn't exist - create new
+            resume_storage_service.create_new_resume(resume_id=resume_id)
+            return templates.TemplateResponse("form.html", {
+                "request": request,
+                "resume_id": resume_id,
+                "is_edit_mode": False,
+                "is_completed": False
+            })
+            
+    except Exception as e:
+        logger.error(f"Error serving resume form for ID {resume_id}: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Error serving resume form: {str(e)}")
+
+
+@app.get("/resume/{resume_id}/view", response_class=HTMLResponse)
+async def view_resume(request: Request, resume_id: str):
+    """View-only mode for shared resumes"""
+    try:
+        if not resume_storage_service.resume_exists(resume_id):
+            raise HTTPException(status_code=404, detail="Resume not found")
+        
+        resume_data = resume_storage_service.get_resume_data(resume_id)
+        if not resume_data or not resume_data.get("data"):
+            raise HTTPException(status_code=404, detail="Resume data not found")
+        
+        # Allow viewing even if resume is not completed (for sharing drafts)
+        # No completion check needed
+        
+        # Render the resume in view-only mode
+        cv_data = CVData(**resume_data["data"])
+        
+        return templates.TemplateResponse("cv_template.html", {
+            "request": request,
+            "cv_data": cv_data,
+            **cv_data.dict(),
+            "is_view_only": True,
+            "resume_id": resume_id
+        })
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error viewing resume {resume_id}: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Error viewing resume: {str(e)}")
+
+
+@app.post("/resume/{resume_id}/save")
+async def save_resume_draft(request: Request, resume_id: str):
+    """Save resume draft data"""
+    try:
+        # Get form data
+        form_data = await request.form()
+        
+        # Parse the form data into structured format
+        structured_data = parse_dynamic_form_data(form_data)
+        
+        # Save to resume storage service
+        success = resume_storage_service.update_resume_data(
+            resume_id, 
+            structured_data, 
+            is_completed=False
+        )
+        
+        if success:
+            return {"status": "success", "message": "Draft saved successfully"}
+        else:
+            raise HTTPException(status_code=500, detail="Failed to save draft")
+            
+    except Exception as e:
+        logger.error(f"Error saving resume draft for ID {resume_id}: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Error saving draft: {str(e)}")
+
+
+@app.get("/resume/{resume_id}/share")
+async def get_shareable_link(request: Request, resume_id: str):
+    """Get shareable link for completed resume"""
+    try:
+        if not resume_storage_service.resume_exists(resume_id):
+            raise HTTPException(status_code=404, detail="Resume not found")
+        
+        resume_data = resume_storage_service.get_resume_data(resume_id)
+        if not resume_data:
+            raise HTTPException(status_code=400, detail="Resume not found")
+        
+        # Generate shareable link
+        base_url = str(request.base_url).rstrip('/')
+        shareable_url = f"{base_url}/resume/{resume_id}/view"
+        
+        return {
+            "status": "success",
+            "shareable_url": shareable_url,
+            "resume_id": resume_id
+        }
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error generating shareable link for resume {resume_id}: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Error generating shareable link: {str(e)}")
 
 
 
@@ -148,7 +287,10 @@ async def download_test_cv_pdf():
         cv_data = CVData(**structured_data)
         
         # Render PDF-specific HTML template
-        html_content = render_template('cv_template_pdf.html', cv_data.dict())
+        html_content = render_template('cv_template_pdf.html', {
+            "cv_data": cv_data,
+            **cv_data.dict()
+        })
         
         # Generate PDF using Playwright
         try:
@@ -270,6 +412,9 @@ async def generate_cv(request: Request):
         form_data = await request.form()
         logger.info(f"[DEBUG] Raw form_data keys: {list(form_data.keys())}")
         
+        # Get resume_id if present
+        resume_id = form_data.get('resume_id')
+        
         # Check if this is a direct PDF download request
         is_pdf_download = form_data.get('download_pdf') == 'true'
         
@@ -294,7 +439,10 @@ async def generate_cv(request: Request):
             cv_data_dict = cv_data.dict()
             logger.info(f"[DEBUG] Direct PDF download - cv_data_dict keys: {list(cv_data_dict.keys())}")
             logger.info(f"[DEBUG] Direct PDF download - font_settings: {cv_data_dict.get('font_settings', 'NOT FOUND')}")
-            html_content = render_template('cv_template_pdf.html', cv_data_dict)
+            html_content = render_template('cv_template_pdf.html', {
+                "cv_data": cv_data,
+                **cv_data_dict
+            })
             
             # Generate PDF using Playwright
             try:
@@ -324,7 +472,10 @@ async def generate_cv(request: Request):
         cv_id = cv_service.generate_cv(cv_data)
         
         # Generate HTML file for display
-        html_content = render_template('cv_template.html', cv_data.dict())
+        html_content = render_template('cv_template.html', {
+            "cv_data": cv_data,
+            **cv_data.dict()
+        })
         
         # Save HTML file
         html_file = BASE_PATH / f"generated/{cv_id}.html"
@@ -352,6 +503,20 @@ async def generate_cv(request: Request):
             f.write(html_with_button)
         
         logger.info(f"CV generated successfully: {cv_id}")
+        
+        # Save data to resume storage service if resume_id is provided
+        if resume_id:
+            try:
+                # Mark resume as completed
+                resume_storage_service.update_resume_data(
+                    resume_id, 
+                    cv_data.dict(), 
+                    is_completed=True
+                )
+                logger.info(f"Resume data saved for ID: {resume_id}")
+            except Exception as e:
+                logger.error(f"Error saving resume data for ID {resume_id}: {str(e)}")
+                # Continue with CV generation even if storage fails
         
         # Return redirect response
         return RedirectResponse(url=f"/cv/{cv_id}", status_code=302)
@@ -730,7 +895,10 @@ async def get_cv_pdf(cv_id: str):
         cv_data_dict = cv_document.data.dict()
         logger.info(f"[DEBUG] PDF generation - cv_data_dict keys: {list(cv_data_dict.keys())}")
         logger.info(f"[DEBUG] PDF generation - font_settings: {cv_data_dict.get('font_settings', 'NOT FOUND')}")
-        html_content = render_template('cv_template_pdf.html', cv_data_dict)
+        html_content = render_template('cv_template_pdf.html', {
+            "cv_data": cv_document.data,
+            **cv_data_dict
+        })
         
         # Generate PDF using Playwright
         try:

--- a/main.py
+++ b/main.py
@@ -16,6 +16,14 @@ from pathlib import Path
 from io import BytesIO
 import pprint
 from playwright.async_api import async_playwright
+from dotenv import load_dotenv
+
+# Load .env file if it exists (for local development only)
+# On server, environment variables are set via systemd service
+env_file_loaded = False
+if os.path.exists(".env"):
+    load_dotenv()
+    env_file_loaded = True
 
 # Import our new models and services
 from app.models.cv_data import CVData, CVGenerateRequest, CVGenerateResponse
@@ -27,6 +35,12 @@ from app.core.logging import setup_logging, get_logger
 # Setup logging
 setup_logging(level="INFO")
 logger = get_logger(__name__)
+
+# Log environment setup
+if env_file_loaded:
+    logger.info("Loaded .env file for local development")
+else:
+    logger.info("No .env file found, using system environment variables")
 
 # Define base path for application files
 BASE_PATH = Path(".")
@@ -51,7 +65,9 @@ templates = Jinja2Templates(directory="templates")
 
 # Initialize services
 cv_service = CVService(base_path=BASE_PATH)
-resume_storage_service = create_resume_storage_service(BASE_PATH, "local")
+# Select storage type via environment (default local)
+storage_type = os.getenv("RESUME_STORAGE_TYPE", "local")
+resume_storage_service = create_resume_storage_service(BASE_PATH, storage_type)
 
 async def generate_pdf_with_playwright(html_content: str) -> bytes:
     """Generate PDF from HTML using Playwright"""

--- a/main.py
+++ b/main.py
@@ -116,16 +116,25 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 # API Endpoints
 @app.get("/", response_class=HTMLResponse)
 async def home(request: Request):
-    """Serve the dynamic CV form - creates new resume with UUID"""
+    """Serve the dynamic CV form - continue last resume or create new"""
     try:
-        # Create a new resume with UUID
-        resume_id = resume_storage_service.create_new_resume()
-        
-        # Redirect to the UUID-based URL
-        return RedirectResponse(url=f"/resume/{resume_id}", status_code=302)
+        # Explicit request to start a new resume ignores cookies/local state
+        new_param = request.query_params.get('new')
+        if new_param and new_param.lower() in ('1', 'true', 'yes'):
+            new_resume_id = resume_storage_service.create_new_resume()
+            return RedirectResponse(url=f"/resume/{new_resume_id}", status_code=302)
+
+        # Allow resume continuation via query param
+        resume_id_param = request.query_params.get('resume_id')
+        if resume_id_param and resume_storage_service.resume_exists(resume_id_param):
+            return RedirectResponse(url=f"/resume/{resume_id_param}", status_code=302)
+
+        # Otherwise, render a tiny bootstrap page to let the browser check localStorage
+        # and redirect accordingly (continue last resume or start new)
+        return templates.TemplateResponse("root_choice.html", {"request": request})
         
     except Exception as e:
-        logger.error(f"Error creating new resume: {str(e)}")
+        logger.error(f"Error creating or continuing resume: {str(e)}")
         # Fall back to empty form
         return templates.TemplateResponse("form.html", {"request": request})
 
@@ -140,7 +149,7 @@ async def resume_form(request: Request, resume_id: str):
             resume_data = resume_storage_service.get_resume_data(resume_id)
             if resume_data and resume_data.get("data"):
                 # Resume exists with data - show in edit mode
-                return templates.TemplateResponse("form.html", {
+                response = templates.TemplateResponse("form.html", {
                     "request": request, 
                     "form_data": resume_data["data"],
                     "resume_id": resume_id,
@@ -149,25 +158,33 @@ async def resume_form(request: Request, resume_id: str):
                 })
             else:
                 # Resume exists but no data - show empty form
-                return templates.TemplateResponse("form.html", {
+                response = templates.TemplateResponse("form.html", {
                     "request": request,
                     "resume_id": resume_id,
                     "is_edit_mode": False,
                     "is_completed": False
                 })
         else:
-            # Resume doesn't exist - create new
+            # Resume doesn't exist - create new shell and show empty form
             resume_storage_service.create_new_resume(resume_id=resume_id)
-            return templates.TemplateResponse("form.html", {
+            response = templates.TemplateResponse("form.html", {
                 "request": request,
                 "resume_id": resume_id,
                 "is_edit_mode": False,
                 "is_completed": False
             })
+
+        return response
             
     except Exception as e:
         logger.error(f"Error serving resume form for ID {resume_id}: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Error serving resume form: {str(e)}")
+
+
+@app.get("/resume/", response_class=HTMLResponse)
+async def resume_form_trailing_slash():
+    """Redirect /resume/ to / to avoid 404 when missing an ID."""
+    return RedirectResponse(url="/", status_code=302)
 
 
 @app.get("/resume/{resume_id}/view", response_class=HTMLResponse)
@@ -546,11 +563,11 @@ def parse_dynamic_form_data(form_data) -> dict:
     }
     # Parse personal info
     structured_data["personal_info"] = {
-        "full_name": form_data.get("full_name", "") or "—",
-        "highest_education": form_data.get("highest_education", "") or "—",
-        "city": form_data.get("city", "") or "—",
-        "phone": form_data.get("phone", "") or "—",
-        "email": form_data.get("email", "") or "notfilled@email.com",
+        "full_name": form_data.get("full_name", ""),
+        "highest_education": form_data.get("highest_education", ""),
+        "city": form_data.get("city", ""),
+        "phone": form_data.get("phone", ""),
+        "email": form_data.get("email", ""),
         "github": form_data.get("github", ""),
         "linkedin": form_data.get("linkedin", "")
     }
@@ -575,13 +592,13 @@ def parse_dynamic_form_data(form_data) -> dict:
         filled_fields = [field for field in ['qualification', 'stream', 'institute', 'year', 'cgpa'] 
                         if entry.get(field, '').strip() and entry.get(field, '').strip() not in ['', '—', 'notfilled@email.com']]
         if filled_fields:
-            # Ensure all fields have values
+            # Keep actual values without forcing dashes for empty fields
             entry = {
-                'qualification': entry.get('qualification', '').strip() or '—',
-                'stream': entry.get('stream', '').strip() or '—',
-                'institute': entry.get('institute', '').strip() or '—',
-                'year': entry.get('year', '').strip() or '—',
-                'cgpa': entry.get('cgpa', '').strip() or '—'
+                'qualification': entry.get('qualification', '').strip(),
+                'stream': entry.get('stream', '').strip(),
+                'institute': entry.get('institute', '').strip(),
+                'year': entry.get('year', '').strip(),
+                'cgpa': entry.get('cgpa', '').strip()
             }
             structured_data["education"].append(entry)
     
@@ -599,10 +616,10 @@ def parse_dynamic_form_data(form_data) -> dict:
         # Only add if description is filled and not just default values
         entry = achievement_data[i]
         if entry.get('description', '').strip() and entry.get('description', '').strip() not in ['', '—', 'notfilled@email.com']:
-            # Ensure all fields have values
+            # Keep actual values without forcing dashes for empty fields
             entry = {
-                'description': entry.get('description', '').strip() or '—',
-                'year': entry.get('year', '').strip() or '—'
+                'description': entry.get('description', '').strip(),
+                'year': entry.get('year', '').strip()
             }
             structured_data["achievements"].append(entry)
     
@@ -620,10 +637,10 @@ def parse_dynamic_form_data(form_data) -> dict:
         # Only add if description is filled and not just default values
         entry = certification_data[i]
         if entry.get('description', '').strip() and entry.get('description', '').strip() not in ['', '—', 'notfilled@email.com']:
-            # Ensure all fields have values
+            # Keep actual values without forcing dashes for empty fields
             entry = {
-                'description': entry.get('description', '').strip() or '—',
-                'year': entry.get('year', '').strip() or '—'
+                'description': entry.get('description', '').strip(),
+                'year': entry.get('year', '').strip()
             }
             structured_data["certifications"].append(entry)
     
@@ -641,10 +658,10 @@ def parse_dynamic_form_data(form_data) -> dict:
         # Only add if description is filled and not just default values
         entry = publication_data[i]
         if entry.get('description', '').strip() and entry.get('description', '').strip() not in ['', '—', 'notfilled@email.com']:
-            # Ensure all fields have values
+            # Keep actual values without forcing dashes for empty fields
             entry = {
-                'description': entry.get('description', '').strip() or '—',
-                'year': entry.get('year', '').strip() or '—'
+                'description': entry.get('description', '').strip(),
+                'year': entry.get('year', '').strip()
             }
             structured_data["publications"].append(entry)
     
@@ -669,11 +686,11 @@ def parse_dynamic_form_data(form_data) -> dict:
                         if entry.get(field, '').strip() and entry.get(field, '').strip() not in ['', '—', 'notfilled@email.com']]
         valid_points = [p for p in entry.get('points', []) if p.strip() and p.strip() not in ['', '—', 'notfilled@email.com']]
         if filled_fields or valid_points:
-            # Ensure all fields have values
+            # Keep actual values without forcing dashes for empty fields
             entry = {
-                'company': entry.get('company', '').strip() or '—',
-                'role': entry.get('role', '').strip() or '—',
-                'duration': entry.get('duration', '').strip() or '—',
+                'company': entry.get('company', '').strip(),
+                'role': entry.get('role', '').strip(),
+                'duration': entry.get('duration', '').strip(),
                 'points': entry.get('points', [])
             }
             structured_data["internships"].append(entry)
@@ -702,9 +719,9 @@ def parse_dynamic_form_data(form_data) -> dict:
             valid_points = [point.strip() for point in entry.get("points", []) 
                           if point.strip() and point.strip() not in ['', '—']]
             entry = {
-                'company': entry.get('company', '').strip() or '—',
-                'position': entry.get('position', '').strip() or '—',
-                'duration': entry.get('duration', '').strip() or '—',
+                'company': entry.get('company', '').strip(),
+                'position': entry.get('position', '').strip(),
+                'duration': entry.get('duration', '').strip(),
                 'points': valid_points
             }
             structured_data["work_experience"].append(entry)
@@ -730,11 +747,11 @@ def parse_dynamic_form_data(form_data) -> dict:
                         if entry.get(field, '').strip() and entry.get(field, '').strip() not in ['', '—', 'notfilled@email.com']]
         valid_points = [p for p in entry.get('points', []) if p.strip() and p.strip() not in ['', '—', 'notfilled@email.com']]
         if filled_fields or valid_points:
-            # Ensure all fields have values
+            # Keep actual values without forcing dashes for empty fields
             entry = {
-                'title': entry.get('title', '').strip() or '—',
-                'type': entry.get('type', '').strip() or '—',
-                'duration': entry.get('duration', '').strip() or '—',
+                'title': entry.get('title', '').strip(),
+                'type': entry.get('type', '').strip(),
+                'duration': entry.get('duration', '').strip(),
                 'repo_link': entry.get('repo_link', ''),
                 'points': entry.get('points', [])
             }
@@ -760,11 +777,11 @@ def parse_dynamic_form_data(form_data) -> dict:
                         if entry.get(field, '').strip() and entry.get(field, '').strip() not in ['', '—', 'notfilled@email.com']]
         valid_points = [p for p in entry.get('points', []) if p.strip() and p.strip() not in ['', '—', 'notfilled@email.com']]
         if filled_fields or valid_points:
-            # Ensure all fields have values
+            # Keep actual values without forcing dashes for empty fields
             entry = {
-                'club': entry.get('club', '').strip() or '—',
-                'role': entry.get('role', '').strip() or '—',
-                'duration': entry.get('duration', '').strip() or '—',
+                'club': entry.get('club', '').strip(),
+                'role': entry.get('role', '').strip(),
+                'duration': entry.get('duration', '').strip(),
                 'points': entry.get('points', [])
             }
             structured_data["positions_of_responsibility"].append(entry)

--- a/main.py
+++ b/main.py
@@ -235,15 +235,16 @@ async def view_resume(request: Request, resume_id: str):
         raise HTTPException(status_code=500, detail=f"Error viewing resume: {str(e)}")
 
 
-@app.get("/api/resume/{resume_id}/exists")
-async def check_resume_exists(resume_id: str):
-    """Check if a resume exists in storage"""
+@app.get("/api/v1/resume/{resume_id}/exists")
+async def resume_exists_api(resume_id: str):
+    """Lightweight existence check for a resume UUID (used by homepage to validate localStorage)."""
     try:
         exists = resume_storage_service.resume_exists(resume_id)
-        return {"exists": exists}
+        return {"resume_id": resume_id, "exists": bool(exists)}
     except Exception as e:
-        logger.error(f"Error checking resume existence: {str(e)}")
-        return {"exists": False}
+        logger.error(f"Error checking existence for resume {resume_id}: {str(e)}")
+        # On error, be safe and report non-existence to trigger a fresh flow
+        return {"resume_id": resume_id, "exists": False}
 
 
 @app.post("/resume/{resume_id}/save")

--- a/main.py
+++ b/main.py
@@ -235,6 +235,17 @@ async def view_resume(request: Request, resume_id: str):
         raise HTTPException(status_code=500, detail=f"Error viewing resume: {str(e)}")
 
 
+@app.get("/api/resume/{resume_id}/exists")
+async def check_resume_exists(resume_id: str):
+    """Check if a resume exists in storage"""
+    try:
+        exists = resume_storage_service.resume_exists(resume_id)
+        return {"exists": exists}
+    except Exception as e:
+        logger.error(f"Error checking resume existence: {str(e)}")
+        return {"exists": False}
+
+
 @app.post("/resume/{resume_id}/save")
 async def save_resume_draft(request: Request, resume_id: str):
     """Save resume draft data"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ aiofiles==23.2.1
 python-dotenv==1.0.0
 playwright>=1.40.0
 pydantic>=2.11.0
+boto3>=1.34.0

--- a/resume_data/05cff839-0380-467d-a7f1-90e344f7c543.json
+++ b/resume_data/05cff839-0380-467d-a7f1-90e344f7c543.json
@@ -1,0 +1,40 @@
+{
+  "resume_id": "05cff839-0380-467d-a7f1-90e344f7c543",
+  "created_at": "2025-08-20T18:04:32.603091",
+  "last_modified": "2025-08-20T18:04:37.836444",
+  "data": {
+    "personal_info": {
+      "full_name": "a",
+      "highest_education": "—",
+      "city": "—",
+      "phone": "—",
+      "email": "notfilled@email.com",
+      "github": "",
+      "linkedin": ""
+    },
+    "education": [],
+    "work_experience": [],
+    "achievements": [],
+    "certifications": [],
+    "publications": [],
+    "internships": [],
+    "projects": [],
+    "positions_of_responsibility": [],
+    "extracurricular": [],
+    "technical_skills": {
+      "programming_languages": [],
+      "web_technologies": [],
+      "database_management": [],
+      "tools_and_technologies": []
+    },
+    "summary": "",
+    "font_settings": {
+      "title_font_size": "12px",
+      "title_font_color": "#4C5196",
+      "body_font_size": "12px",
+      "body_font_color": "#000000",
+      "line_height": "1.1"
+    }
+  },
+  "is_completed": false
+}

--- a/resume_data/105724ff-593c-40eb-8b52-1a6fec1d8e50.json
+++ b/resume_data/105724ff-593c-40eb-8b52-1a6fec1d8e50.json
@@ -1,0 +1,7 @@
+{
+  "resume_id": "105724ff-593c-40eb-8b52-1a6fec1d8e50",
+  "created_at": "2025-08-20T16:29:41.588328",
+  "last_modified": "2025-08-20T16:29:41.588333",
+  "data": {},
+  "is_completed": false
+}

--- a/resume_data/1a58b285-a06b-4b7e-99fc-31690ea09766.json
+++ b/resume_data/1a58b285-a06b-4b7e-99fc-31690ea09766.json
@@ -1,0 +1,7 @@
+{
+  "resume_id": "1a58b285-a06b-4b7e-99fc-31690ea09766",
+  "created_at": "2025-08-15T07:49:59.494228",
+  "last_modified": "2025-08-15T07:49:59.494228",
+  "data": {},
+  "is_completed": false
+}

--- a/resume_data/3601642a-d5e3-4562-b11a-991f31cb0d7e.json
+++ b/resume_data/3601642a-d5e3-4562-b11a-991f31cb0d7e.json
@@ -1,0 +1,48 @@
+{
+  "resume_id": "3601642a-d5e3-4562-b11a-991f31cb0d7e",
+  "created_at": "2025-08-15T08:08:47.329296",
+  "last_modified": "2025-08-15T08:46:19.535382",
+  "data": {
+    "personal_info": {
+      "full_name": "Amit Diwakar",
+      "highest_education": "B.Tech.",
+      "city": "—",
+      "phone": "06395490029",
+      "email": "amitdiwakar946@gmail.com",
+      "github": "",
+      "linkedin": ""
+    },
+    "education": [
+      {
+        "qualification": "B.tech",
+        "stream": "—",
+        "institute": "IIT",
+        "year": "2023",
+        "cgpa": "—"
+      }
+    ],
+    "work_experience": [],
+    "achievements": [],
+    "certifications": [],
+    "publications": [],
+    "internships": [],
+    "projects": [],
+    "positions_of_responsibility": [],
+    "extracurricular": [],
+    "technical_skills": {
+      "programming_languages": [],
+      "web_technologies": [],
+      "database_management": [],
+      "tools_and_technologies": []
+    },
+    "summary": "A motivational ",
+    "font_settings": {
+      "title_font_size": "12px",
+      "title_font_color": "#4C5196",
+      "body_font_size": "12px",
+      "body_font_color": "#000000",
+      "line_height": "1.1"
+    }
+  },
+  "is_completed": false
+}

--- a/resume_data/3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0.json
+++ b/resume_data/3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0.json
@@ -1,0 +1,40 @@
+{
+  "resume_id": "3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0",
+  "created_at": "2025-08-20T18:29:23.283416",
+  "last_modified": "2025-08-20T18:35:34.110970",
+  "data": {
+    "personal_info": {
+      "full_name": "aadasd ",
+      "highest_education": "asd",
+      "city": "",
+      "phone": "",
+      "email": "",
+      "github": "",
+      "linkedin": ""
+    },
+    "education": [],
+    "work_experience": [],
+    "achievements": [],
+    "certifications": [],
+    "publications": [],
+    "internships": [],
+    "projects": [],
+    "positions_of_responsibility": [],
+    "extracurricular": [],
+    "technical_skills": {
+      "programming_languages": [],
+      "web_technologies": [],
+      "database_management": [],
+      "tools_and_technologies": []
+    },
+    "summary": "",
+    "font_settings": {
+      "title_font_size": "12px",
+      "title_font_color": "#4C5196",
+      "body_font_size": "12px",
+      "body_font_color": "#000000",
+      "line_height": "1.1"
+    }
+  },
+  "is_completed": false
+}

--- a/resume_data/4237fb08-98f3-4c9b-b486-6de9b91c1548.json
+++ b/resume_data/4237fb08-98f3-4c9b-b486-6de9b91c1548.json
@@ -1,0 +1,40 @@
+{
+  "resume_id": "4237fb08-98f3-4c9b-b486-6de9b91c1548",
+  "created_at": "2025-08-20T17:54:22.564609",
+  "last_modified": "2025-08-20T17:59:27.499946",
+  "data": {
+    "personal_info": {
+      "full_name": "—",
+      "highest_education": "—",
+      "city": "—",
+      "phone": "—",
+      "email": "notfilled@email.com",
+      "github": "",
+      "linkedin": ""
+    },
+    "education": [],
+    "work_experience": [],
+    "achievements": [],
+    "certifications": [],
+    "publications": [],
+    "internships": [],
+    "projects": [],
+    "positions_of_responsibility": [],
+    "extracurricular": [],
+    "technical_skills": {
+      "programming_languages": [],
+      "web_technologies": [],
+      "database_management": [],
+      "tools_and_technologies": []
+    },
+    "summary": "",
+    "font_settings": {
+      "title_font_size": "12px",
+      "title_font_color": "#4C5196",
+      "body_font_size": "12px",
+      "body_font_color": "#000000",
+      "line_height": "1.1"
+    }
+  },
+  "is_completed": false
+}

--- a/resume_data/5a5e798d-0a28-4801-9767-9197b52b3bda.json
+++ b/resume_data/5a5e798d-0a28-4801-9767-9197b52b3bda.json
@@ -1,0 +1,48 @@
+{
+  "resume_id": "5a5e798d-0a28-4801-9767-9197b52b3bda",
+  "created_at": "2025-08-15T08:46:47.985442",
+  "last_modified": "2025-08-15T08:47:12.487817",
+  "data": {
+    "personal_info": {
+      "full_name": "Amit Diwakar",
+      "highest_education": "—",
+      "city": "—",
+      "phone": "06395490029",
+      "email": "amitdiwakar946@gmail.com",
+      "github": "",
+      "linkedin": ""
+    },
+    "education": [
+      {
+        "qualification": "B.tech",
+        "stream": "—",
+        "institute": "IIT",
+        "year": "2023",
+        "cgpa": "—"
+      }
+    ],
+    "work_experience": [],
+    "achievements": [],
+    "certifications": [],
+    "publications": [],
+    "internships": [],
+    "projects": [],
+    "positions_of_responsibility": [],
+    "extracurricular": [],
+    "technical_skills": {
+      "programming_languages": [],
+      "web_technologies": [],
+      "database_management": [],
+      "tools_and_technologies": []
+    },
+    "summary": "",
+    "font_settings": {
+      "title_font_size": "12px",
+      "title_font_color": "#4C5196",
+      "body_font_size": "12px",
+      "body_font_color": "#000000",
+      "line_height": "1.1"
+    }
+  },
+  "is_completed": false
+}

--- a/resume_data/5d2ff6fd-493a-4225-b8db-9006aa517cb0.json
+++ b/resume_data/5d2ff6fd-493a-4225-b8db-9006aa517cb0.json
@@ -1,0 +1,48 @@
+{
+  "resume_id": "5d2ff6fd-493a-4225-b8db-9006aa517cb0",
+  "created_at": "2025-08-15T09:45:02.986940",
+  "last_modified": "2025-08-15T09:45:11.346997",
+  "data": {
+    "personal_info": {
+      "full_name": "Amit Diwakar",
+      "highest_education": "—",
+      "city": "—",
+      "phone": "06395490029",
+      "email": "amitdiwakar946@gmail.com",
+      "github": "",
+      "linkedin": ""
+    },
+    "education": [
+      {
+        "qualification": "B.tech",
+        "stream": "—",
+        "institute": "IIT",
+        "year": "2023",
+        "cgpa": "—"
+      }
+    ],
+    "work_experience": [],
+    "achievements": [],
+    "certifications": [],
+    "publications": [],
+    "internships": [],
+    "projects": [],
+    "positions_of_responsibility": [],
+    "extracurricular": [],
+    "technical_skills": {
+      "programming_languages": [],
+      "web_technologies": [],
+      "database_management": [],
+      "tools_and_technologies": []
+    },
+    "summary": "",
+    "font_settings": {
+      "title_font_size": "12px",
+      "title_font_color": "#4C5196",
+      "body_font_size": "12px",
+      "body_font_color": "#000000",
+      "line_height": "1.1"
+    }
+  },
+  "is_completed": false
+}

--- a/resume_data/65e8eb0f-2c28-420a-a6f2-49c0dc3ab2e5.json
+++ b/resume_data/65e8eb0f-2c28-420a-a6f2-49c0dc3ab2e5.json
@@ -1,0 +1,48 @@
+{
+  "resume_id": "65e8eb0f-2c28-420a-a6f2-49c0dc3ab2e5",
+  "created_at": "2025-08-15T09:59:04.122914",
+  "last_modified": "2025-08-15T09:59:13.675545",
+  "data": {
+    "personal_info": {
+      "full_name": "Amit Diwakar",
+      "highest_education": "—",
+      "city": "—",
+      "phone": "06395490029",
+      "email": "amitdiwakar946@gmail.com",
+      "github": "",
+      "linkedin": ""
+    },
+    "education": [
+      {
+        "qualification": "B.tech",
+        "stream": "—",
+        "institute": "IIT",
+        "year": "2023",
+        "cgpa": "—"
+      }
+    ],
+    "work_experience": [],
+    "achievements": [],
+    "certifications": [],
+    "publications": [],
+    "internships": [],
+    "projects": [],
+    "positions_of_responsibility": [],
+    "extracurricular": [],
+    "technical_skills": {
+      "programming_languages": [],
+      "web_technologies": [],
+      "database_management": [],
+      "tools_and_technologies": []
+    },
+    "summary": "",
+    "font_settings": {
+      "title_font_size": "12px",
+      "title_font_color": "#4C5196",
+      "body_font_size": "12px",
+      "body_font_color": "#000000",
+      "line_height": "1.1"
+    }
+  },
+  "is_completed": false
+}

--- a/resume_data/9b7a6b0a-37f8-46f1-8a5e-26755d74dc24.json
+++ b/resume_data/9b7a6b0a-37f8-46f1-8a5e-26755d74dc24.json
@@ -1,0 +1,7 @@
+{
+  "resume_id": "9b7a6b0a-37f8-46f1-8a5e-26755d74dc24",
+  "created_at": "2025-08-20T16:24:29.088824",
+  "last_modified": "2025-08-20T16:24:29.088838",
+  "data": {},
+  "is_completed": false
+}

--- a/resume_data/9fec453c-b48c-4a87-b1ed-b3c7928d5324.json
+++ b/resume_data/9fec453c-b48c-4a87-b1ed-b3c7928d5324.json
@@ -1,0 +1,40 @@
+{
+  "resume_id": "9fec453c-b48c-4a87-b1ed-b3c7928d5324",
+  "created_at": "2025-08-20T18:05:23.553177",
+  "last_modified": "2025-08-20T18:05:27.730404",
+  "data": {
+    "personal_info": {
+      "full_name": "asd",
+      "highest_education": "—",
+      "city": "—",
+      "phone": "—",
+      "email": "notfilled@email.com",
+      "github": "",
+      "linkedin": ""
+    },
+    "education": [],
+    "work_experience": [],
+    "achievements": [],
+    "certifications": [],
+    "publications": [],
+    "internships": [],
+    "projects": [],
+    "positions_of_responsibility": [],
+    "extracurricular": [],
+    "technical_skills": {
+      "programming_languages": [],
+      "web_technologies": [],
+      "database_management": [],
+      "tools_and_technologies": []
+    },
+    "summary": "",
+    "font_settings": {
+      "title_font_size": "12px",
+      "title_font_color": "#4C5196",
+      "body_font_size": "12px",
+      "body_font_color": "#000000",
+      "line_height": "1.1"
+    }
+  },
+  "is_completed": false
+}

--- a/resume_data/ae896ab6-a6ba-4086-80ed-793373d161e9.json
+++ b/resume_data/ae896ab6-a6ba-4086-80ed-793373d161e9.json
@@ -1,0 +1,58 @@
+{
+  "resume_id": "ae896ab6-a6ba-4086-80ed-793373d161e9",
+  "created_at": "2025-08-15T07:37:10.488793",
+  "last_modified": "2025-08-15T08:07:58.136592",
+  "data": {
+    "personal_info": {
+      "full_name": "AMIT",
+      "highest_education": "—",
+      "city": "Agra",
+      "phone": "04563726377",
+      "email": "amit@gmail.com",
+      "github": "",
+      "linkedin": ""
+    },
+    "education": [],
+    "work_experience": [],
+    "achievements": [],
+    "certifications": [],
+    "publications": [],
+    "internships": [
+      {
+        "company": "Chapoint",
+        "role": "—",
+        "duration": "—",
+        "points": [
+          ""
+        ]
+      }
+    ],
+    "projects": [],
+    "positions_of_responsibility": [
+      {
+        "club": "Chapoint",
+        "role": "—",
+        "duration": "—",
+        "points": [
+          ""
+        ]
+      }
+    ],
+    "extracurricular": [],
+    "technical_skills": {
+      "programming_languages": [],
+      "web_technologies": [],
+      "database_management": [],
+      "tools_and_technologies": []
+    },
+    "summary": "jksdskfklsd",
+    "font_settings": {
+      "title_font_size": "12px",
+      "title_font_color": "#4C5196",
+      "body_font_size": "12px",
+      "body_font_color": "#000000",
+      "line_height": "1.1"
+    }
+  },
+  "is_completed": false
+}

--- a/resume_data/c297c36c-86b9-4d63-ba54-c92a69233e9d.json
+++ b/resume_data/c297c36c-86b9-4d63-ba54-c92a69233e9d.json
@@ -1,0 +1,7 @@
+{
+  "resume_id": "c297c36c-86b9-4d63-ba54-c92a69233e9d",
+  "created_at": "2025-08-20T16:27:22.651013",
+  "last_modified": "2025-08-20T16:27:22.651018",
+  "data": {},
+  "is_completed": false
+}

--- a/resume_data/e1d068b1-8f3f-4fb2-b55d-2749b3915e5f.json
+++ b/resume_data/e1d068b1-8f3f-4fb2-b55d-2749b3915e5f.json
@@ -1,0 +1,40 @@
+{
+  "resume_id": "e1d068b1-8f3f-4fb2-b55d-2749b3915e5f",
+  "created_at": "2025-08-20T17:41:15.170758",
+  "last_modified": "2025-08-20T17:43:23.967147",
+  "data": {
+    "personal_info": {
+      "full_name": "ads",
+      "highest_education": "—",
+      "city": "—",
+      "phone": "—",
+      "email": "notfilled@email.com",
+      "github": "",
+      "linkedin": ""
+    },
+    "education": [],
+    "work_experience": [],
+    "achievements": [],
+    "certifications": [],
+    "publications": [],
+    "internships": [],
+    "projects": [],
+    "positions_of_responsibility": [],
+    "extracurricular": [],
+    "technical_skills": {
+      "programming_languages": [],
+      "web_technologies": [],
+      "database_management": [],
+      "tools_and_technologies": []
+    },
+    "summary": "",
+    "font_settings": {
+      "title_font_size": "12px",
+      "title_font_color": "#4C5196",
+      "body_font_size": "12px",
+      "body_font_color": "#000000",
+      "line_height": "1.1"
+    }
+  },
+  "is_completed": false
+}

--- a/resume_data/f1610e62-e4cb-4988-98cd-3c2e14f369a3.json
+++ b/resume_data/f1610e62-e4cb-4988-98cd-3c2e14f369a3.json
@@ -1,0 +1,7 @@
+{
+  "resume_id": "f1610e62-e4cb-4988-98cd-3c2e14f369a3",
+  "created_at": "2025-08-20T16:24:56.761288",
+  "last_modified": "2025-08-20T16:24:56.761292",
+  "data": {},
+  "is_completed": false
+}

--- a/resume_data/resume_metadata.json
+++ b/resume_data/resume_metadata.json
@@ -31,6 +31,51 @@
       "created_at": "2025-08-15T09:59:04.122914",
       "last_modified": "2025-08-15T09:59:13.675545",
       "is_completed": false
+    },
+    "9b7a6b0a-37f8-46f1-8a5e-26755d74dc24": {
+      "created_at": "2025-08-20T16:24:29.088824",
+      "last_modified": "2025-08-20T16:24:29.088838",
+      "is_completed": false
+    },
+    "f1610e62-e4cb-4988-98cd-3c2e14f369a3": {
+      "created_at": "2025-08-20T16:24:56.761288",
+      "last_modified": "2025-08-20T16:24:56.761292",
+      "is_completed": false
+    },
+    "c297c36c-86b9-4d63-ba54-c92a69233e9d": {
+      "created_at": "2025-08-20T16:27:22.651013",
+      "last_modified": "2025-08-20T16:27:22.651018",
+      "is_completed": false
+    },
+    "105724ff-593c-40eb-8b52-1a6fec1d8e50": {
+      "created_at": "2025-08-20T16:29:41.588328",
+      "last_modified": "2025-08-20T16:29:41.588333",
+      "is_completed": false
+    },
+    "e1d068b1-8f3f-4fb2-b55d-2749b3915e5f": {
+      "created_at": "2025-08-20T17:41:15.170758",
+      "last_modified": "2025-08-20T17:43:23.967147",
+      "is_completed": false
+    },
+    "4237fb08-98f3-4c9b-b486-6de9b91c1548": {
+      "created_at": "2025-08-20T17:54:22.564609",
+      "last_modified": "2025-08-20T17:59:27.499946",
+      "is_completed": false
+    },
+    "05cff839-0380-467d-a7f1-90e344f7c543": {
+      "created_at": "2025-08-20T18:04:32.603091",
+      "last_modified": "2025-08-20T18:04:37.836444",
+      "is_completed": false
+    },
+    "9fec453c-b48c-4a87-b1ed-b3c7928d5324": {
+      "created_at": "2025-08-20T18:05:23.553177",
+      "last_modified": "2025-08-20T18:05:27.730404",
+      "is_completed": false
+    },
+    "3aeb6ea8-af02-4c8d-97a9-9a1278b1ccd0": {
+      "created_at": "2025-08-20T18:29:23.283416",
+      "last_modified": "2025-08-20T18:35:34.110970",
+      "is_completed": false
     }
   }
 }

--- a/resume_data/resume_metadata.json
+++ b/resume_data/resume_metadata.json
@@ -1,0 +1,36 @@
+{
+  "version": "1.0",
+  "created_at": "2025-08-15T07:36:47.243341",
+  "resumes": {
+    "ae896ab6-a6ba-4086-80ed-793373d161e9": {
+      "created_at": "2025-08-15T07:37:10.488793",
+      "last_modified": "2025-08-15T08:07:58.136592",
+      "is_completed": false
+    },
+    "1a58b285-a06b-4b7e-99fc-31690ea09766": {
+      "created_at": "2025-08-15T07:49:59.494228",
+      "last_modified": "2025-08-15T07:49:59.494228",
+      "is_completed": false
+    },
+    "3601642a-d5e3-4562-b11a-991f31cb0d7e": {
+      "created_at": "2025-08-15T08:08:47.329296",
+      "last_modified": "2025-08-15T08:46:19.535382",
+      "is_completed": false
+    },
+    "5a5e798d-0a28-4801-9767-9197b52b3bda": {
+      "created_at": "2025-08-15T08:46:47.985442",
+      "last_modified": "2025-08-15T08:47:12.487817",
+      "is_completed": false
+    },
+    "5d2ff6fd-493a-4225-b8db-9006aa517cb0": {
+      "created_at": "2025-08-15T09:45:02.986940",
+      "last_modified": "2025-08-15T09:45:11.346997",
+      "is_completed": false
+    },
+    "65e8eb0f-2c28-420a-a6f2-49c0dc3ab2e5": {
+      "created_at": "2025-08-15T09:59:04.122914",
+      "last_modified": "2025-08-15T09:59:13.675545",
+      "is_completed": false
+    }
+  }
+}

--- a/templates/cv_template.html
+++ b/templates/cv_template.html
@@ -4,6 +4,34 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CV - {{personal_info.full_name}}</title>
+    {% if is_view_only %}
+    <style>
+        .view-only-banner {
+            background-color: #e3f2fd;
+            border: 1px solid #2196f3;
+            border-radius: 5px;
+            padding: 15px;
+            margin-bottom: 20px;
+            text-align: center;
+            font-family: Arial, sans-serif;
+        }
+        .view-only-banner h2 {
+            margin: 0 0 10px 0;
+            color: #1976d2;
+        }
+        .view-only-banner p {
+            margin: 0 0 15px 0;
+            color: #424242;
+        }
+        .view-only-banner .resume-id {
+            background-color: #f5f5f5;
+            padding: 8px 12px;
+            border-radius: 3px;
+            font-family: monospace;
+            margin: 10px 0;
+        }
+    </style>
+    {% endif %}
     <style>
         body {
             font-family: 'Times New Roman', Times, serif, sans-serif;
@@ -144,6 +172,19 @@
     </style>
 </head>
 <body>
+    {% if is_view_only %}
+                    <div class="view-only-banner">
+                    <h2>📄 Resume Preview</h2>
+                    <p>This is a view-only version of the resume. The original creator can edit this resume using the edit URL.</p>
+                    <div class="resume-id">
+                        <strong>Resume ID:</strong> {{ resume_id }}
+                    </div>
+                    <p style="font-size: 14px; color: #666;">
+                        💡 <strong>Note:</strong> This is a shared resume. To create your own resume, visit the main CV Generator.
+                    </p>
+                </div>
+    {% endif %}
+    
     <div class="header">
         <div class="name">{{personal_info.full_name}}</div>
         <div class="contact-info">

--- a/templates/cv_template_pdf.html
+++ b/templates/cv_template_pdf.html
@@ -4,6 +4,34 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CV - {{personal_info.full_name}}</title>
+    {% if is_view_only %}
+    <style>
+        .view-only-banner {
+            background-color: #e3f2fd;
+            border: 1px solid #2196f3;
+            border-radius: 5px;
+            padding: 15px;
+            margin-bottom: 20px;
+            text-align: center;
+            font-family: Arial, sans-serif;
+        }
+        .view-only-banner h2 {
+            margin: 0 0 10px 0;
+            color: #1976d2;
+        }
+        .view-only-banner p {
+            margin: 0 0 15px 0;
+            color: #424242;
+        }
+        .view-only-banner .resume-id {
+            background-color: #f5f5f5;
+            padding: 8px 12px;
+            border-radius: 3px;
+            font-family: monospace;
+            margin: 10px 0;
+        }
+    </style>
+    {% endif %}
     <style>
         body {
             font-family: 'Times New Roman', Times, serif, sans-serif;
@@ -213,6 +241,19 @@
     </style>
 </head>
 <body>
+    {% if is_view_only %}
+                    <div class="view-only-banner">
+                    <h2>📄 Resume Preview</h2>
+                    <p>This is a view-only version of the resume. The original creator can edit this resume using the edit URL.</p>
+                    <div class="resume-id">
+                        <strong>Resume ID:</strong> {{ resume_id }}
+                    </div>
+                    <p style="font-size: 14px; color: #666;">
+                        💡 <strong>Note:</strong> This is a shared resume. To create your own resume, visit the main CV Generator.
+                    </p>
+                </div>
+    {% endif %}
+    
     <div class="pdf-fit-wrapper">
         <div class="header">
             <div class="name">{{personal_info.full_name}}</div>

--- a/templates/form.html
+++ b/templates/form.html
@@ -409,6 +409,57 @@
             overflow-y: visible;
         }
     }
+    
+    /* Save Status Styles */
+    .save-status-saved {
+        background-color: #f0f9f0;
+        border-left-color: #22c55e !important;
+        color: #16a34a;
+    }
+    
+    .save-status-unsaved {
+        background-color: #fff7ed;
+        border-left-color: #f59e0b !important;
+        color: #d97706;
+    }
+    
+    .save-status-icon {
+        margin-right: 6px;
+        display: inline-block;
+    }
+    
+    /* Loading spinner animation */
+    .spinner {
+        display: inline-block;
+        width: 12px;
+        height: 12px;
+        border: 2px solid #f3f3f3;
+        border-top: 2px solid #d97706;
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+        margin-right: 6px;
+    }
+    
+    @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+    }
+    
+    /* Status message fade-in animation */
+    .status-fade-in {
+        animation: statusFadeIn 0.3s ease-out;
+    }
+    
+    @keyframes statusFadeIn {
+        from {
+            opacity: 0;
+            transform: translateY(-10px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
     </style>
 </head>
 <body>
@@ -945,6 +996,11 @@
                 </button>
             </div>
         </div>
+        <!-- Status Message -->
+        <div id="save-status-container" style="display: none; margin-bottom: 15px; font-size: 12px; padding: 8px 12px; border-radius: 4px; border-left: 4px solid;">
+            <span id="save-status-icon"></span>
+            <span id="save-status-text"></span>
+        </div>
         <div id="cv-preview-container"></div>
     </div>
     </div>
@@ -953,6 +1009,30 @@
     <script>
         // Resume management variables
         let currentResumeId = '{{ resume_id if resume_id else "" }}';
+        // localStorage helpers for resuming recent work
+        function saveToLocalStorage(resumeId) {
+            if (!resumeId) return;
+            try {
+                localStorage.setItem('lastResumeId', resumeId);
+                localStorage.setItem('lastResumeTimestamp', String(Date.now()));
+            } catch (e) {
+                console.warn('localStorage not available:', e);
+            }
+        }
+
+        function getLastResumeFromStorage(maxAgeDays = 7) {
+            try {
+                const lastId = localStorage.getItem('lastResumeId');
+                const ts = localStorage.getItem('lastResumeTimestamp');
+                if (!lastId || !ts) return null;
+                const ageMs = Date.now() - Number(ts);
+                if (isNaN(ageMs)) return lastId; // if ts invalid, still return id
+                if (ageMs < maxAgeDays * 24 * 60 * 60 * 1000) return lastId;
+            } catch (e) {
+                console.warn('localStorage not available:', e);
+            }
+            return null;
+        }
         let autoSaveTimer = null;
         let isEditMode = {{ 'true' if is_edit_mode else 'false' }};
         let isCompleted = {{ 'true' if is_completed else 'false' }};
@@ -1777,6 +1857,8 @@
         const educationEntries = getArrayEntries('education');
         const workExperienceEntries = getArrayEntries('work_experience');
         const achievementEntries = getArrayEntries('achievements');
+        const certificationEntries = getArrayEntries('certifications');
+        const publicationEntries = getArrayEntries('publications');
         const internshipEntries = getArrayEntries('internships');
         const projectEntries = getArrayEntries('projects');
         const positionEntries = getArrayEntries('positions');
@@ -1789,6 +1871,8 @@
         const hasEducation = educationEntries.some(entry => entry.qualification || entry.stream || entry.institute);
         const hasWorkExperience = workExperienceEntries.some(entry => entry.company || entry.position);
         const hasAchievements = achievementEntries.some(entry => entry.description);
+        const hasCertifications = certificationEntries.some(entry => entry.description);
+        const hasPublications = publicationEntries.some(entry => entry.description);
         const hasInternships = internshipEntries.some(entry => entry.company || entry.role);
         const hasProjects = projectEntries.some(entry => entry.title || entry.type);
         const hasPositions = positionEntries.some(entry => entry.club || entry.role);
@@ -1812,7 +1896,7 @@
         // If no data is filled, show empty page
         if (!hasPersonalInfo && !hasSummary && !hasEducation && !hasWorkExperience && !hasAchievements && 
             !hasCertifications && !hasPublications && !hasInternships && !hasProjects && !hasPositions && !hasActivities && !hasSkills) {
-            preview.innerHTML = '<div class="cv-preview" style="font-family: Times New Roman, Times, serif; max-width: 794px; min-height: 1123px; background: #fff; padding: 32px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; color: #999; font-size: 1.2em;">Empty CV Preview<br><span style="font-size: 0.8em;">Start filling the form to see your CV here</span></div>';
+            preview.innerHTML = '<div class="cv-preview" style="font-family: Times New Roman, Times, serif; max-width: 794px; min-height: 1123px; background: #fff; padding: 32px; box-sizing: border-box; display: flex; flex-direction: column; align-items: center; justify-content: center; color: #999; font-size: 1.2em; text-align: center;">Empty CV Preview<br><span style="font-size: 0.8em;">Start filling the form to see your CV here</span></div>';
             return;
         }
         
@@ -2016,8 +2100,6 @@
         }
 
         // Certifications - only show if there are actual certifications with content
-        const certificationEntries = getArrayEntries('certifications');
-        const hasCertifications = certificationEntries.some(entry => entry.description);
         if (hasCertifications) {
             html += `<div style="margin-bottom:20px;">`;
             html += `<div style="display:flex;align-items:center;margin-bottom:10px;">
@@ -2045,8 +2127,6 @@
         }
 
         // Publications - only show if there are actual publications with content
-        const publicationEntries = getArrayEntries('publications');
-        const hasPublications = publicationEntries.some(entry => entry.description);
         if (hasPublications) {
             html += `<div style="margin-bottom:20px;">`;
             html += `<div style="display:flex;align-items:center;margin-bottom:10px;">
@@ -2537,14 +2617,24 @@
     
     // Initialize font settings inputs on page load
     document.addEventListener('DOMContentLoaded', function() {
+        // If on root, optionally continue last resume from localStorage by redirecting with query param
+        if (window.location.pathname === '/') {
+            const lastId = getLastResumeFromStorage();
+            if (lastId) {
+                window.location.href = `/?resume_id=${encodeURIComponent(lastId)}`;
+                return;
+            }
+        }
+
         updateFontSettingsInputs();
-        
+
         // Initialize auto-save if resume ID exists
         if (currentResumeId) {
             initializeAutoSave();
             showResumeInfo();
+            saveToLocalStorage(currentResumeId);
         }
-        
+
         // Add beforeunload event for URL copy popup
         window.addEventListener('beforeunload', function(e) {
             if (currentResumeId && !isCompleted) {
@@ -2555,6 +2645,59 @@
         });
     });
     
+    // Save status management
+    let hasUserMadeChanges = false;
+    
+    function showSaveStatus(status, timestamp = null) {
+        if (!hasUserMadeChanges) return; // Don't show until user has made changes
+        
+        const container = document.getElementById('save-status-container');
+        const icon = document.getElementById('save-status-icon');
+        const text = document.getElementById('save-status-text');
+        
+        if (!container || !icon || !text) return;
+        
+        // Remove existing classes
+        container.className = container.className.replace(/save-status-\w+/g, '');
+        
+        if (status === 'saved') {
+            container.classList.add('save-status-saved');
+            icon.innerHTML = '✓';
+            icon.className = 'save-status-icon';
+            
+            const time = timestamp || new Date().toLocaleTimeString('en-US', { 
+                hour12: false, 
+                hour: '2-digit', 
+                minute: '2-digit', 
+                second: '2-digit' 
+            });
+            text.textContent = `Changes saved last at ${time}`;
+            
+        } else if (status === 'unsaved') {
+            container.classList.add('save-status-unsaved');
+            icon.innerHTML = '';
+            icon.className = 'save-status-icon spinner';
+            text.textContent = 'Unsaved changes present ... auto saving';
+        }
+        
+        // Show container with animation if hidden
+        if (container.style.display === 'none') {
+            container.style.display = 'block';
+            container.classList.add('status-fade-in');
+            
+            // Remove animation class after animation completes
+            setTimeout(() => {
+                container.classList.remove('status-fade-in');
+            }, 300);
+        }
+    }
+    
+    function markUserChangeMade() {
+        if (!hasUserMadeChanges) {
+            hasUserMadeChanges = true;
+        }
+    }
+
     // Auto-save functionality
     function initializeAutoSave() {
         const form = document.getElementById('cvForm');
@@ -2562,6 +2705,8 @@
         
         // Auto-save on form changes
         form.addEventListener('input', function() {
+            markUserChangeMade();
+            showSaveStatus('unsaved');
             clearTimeout(autoSaveTimer);
             autoSaveTimer = setTimeout(function() {
                 autoSaveDraft();
@@ -2590,7 +2735,7 @@
             
             if (response.ok) {
                 console.log('Draft saved successfully');
-                // Don't show notification for auto-save to avoid spam
+                showSaveStatus('saved');
                 return Promise.resolve();
             } else {
                 console.error('Failed to save draft');
@@ -2665,6 +2810,9 @@
                 <br>💡 <strong>Tip:</strong> Copy the Edit URL to return to edit this resume later. 
                 Click "Copy Share URL" to copy the shareable link for others to view your resume.
             </div>
+            <div style="margin-top: 12px;">
+                <button type="button" onclick="startNewResume()" style="padding: 6px 10px; background-color: #6c757d; color: #fff; border: none; border-radius: 4px; cursor: pointer;">Start new resume</button>
+            </div>
         `;
         
         header.parentNode.insertBefore(resumeInfo, header.nextSibling);
@@ -2714,6 +2862,16 @@
         if (cvForm) {
             cvForm.submit();
         }
+    }
+
+    // Start new resume function
+    function startNewResume() {
+        // Optionally clear stored last resume
+        try {
+            localStorage.removeItem('lastResumeId');
+            localStorage.removeItem('lastResumeTimestamp');
+        } catch (e) { /* ignore */ }
+        window.location.href = '/?new=1';
     }
     </script>
 </body>

--- a/templates/form.html
+++ b/templates/form.html
@@ -77,6 +77,55 @@
         button:hover {
             background-color: #3182ce;
         }
+        
+        /* Resume management styles */
+        .resume-info {
+            background-color: #e3f2fd;
+            border: 1px solid #2196f3;
+            border-radius: 5px;
+            padding: 15px;
+            margin-bottom: 20px;
+            text-align: center;
+        }
+        
+        .resume-info input[readonly] {
+            background-color: #f5f5f5;
+            border: 1px solid #ddd;
+            color: #666;
+        }
+        
+        .resume-info button {
+            width: auto;
+            margin: 0 0 0 10px;
+            padding: 5px 10px;
+            font-size: 14px;
+        }
+        
+        .save-notification {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            background-color: #2196f3;
+            color: white;
+            padding: 12px 24px;
+            border-radius: 8px;
+            z-index: 1000;
+            font-size: 16px;
+            font-weight: bold;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+            animation: slideIn 0.3s ease-out;
+        }
+        
+        @keyframes slideIn {
+            from {
+                transform: translateX(100%);
+                opacity: 0;
+            }
+            to {
+                transform: translateX(0);
+                opacity: 1;
+            }
+        }
         .required {
             color: red;
         }
@@ -448,6 +497,10 @@
             </button> -->
         </div>
         <form id="cvForm" method="post" action="/generate">
+            <!-- Hidden fields for resume management -->
+            {% if resume_id %}
+            <input type="hidden" name="resume_id" value="{{ resume_id }}">
+            {% endif %}
             
             <!-- Personal Information -->
             <div class="section">
@@ -851,8 +904,26 @@
                 </div>
             </div>
 
-            <!-- Generate CV button removed as per Task 6 -->
+            <!-- Form Action Buttons -->
+            <div style="display: flex; gap: 15px; margin-top: 30px;">
+                {% if resume_id %}
+                <button type="button" onclick="copyEditUrl()" style="flex: 1; background-color: #2196f3; padding: 15px 30px; font-size: 16px; border: none; border-radius: 5px; color: white; cursor: pointer;">
+                    📋 Copy Edit URL
+                </button>
+                {% endif %}
+                <button type="button" onclick="shareResume()" style="flex: 1; background-color: #4caf50; padding: 15px 30px; font-size: 16px; border: none; border-radius: 5px; color: white; cursor: pointer;">
+                    📋 Copy Share URL
+                </button>
+            </div>
         </form>
+        
+        <!-- Hidden form for CV generation -->
+        {% if resume_id %}
+        <form id="cvGenerateForm" method="post" action="/generate" style="display: none;">
+            <input type="hidden" name="resume_id" value="{{ resume_id }}">
+            <input type="hidden" name="download_pdf" value="true">
+        </form>
+        {% endif %}
         
         <!-- Bottom Download PDF Button -->
         <div style="text-align: center; margin-top: 30px;">
@@ -880,6 +951,12 @@
     
 
     <script>
+        // Resume management variables
+        let currentResumeId = '{{ resume_id if resume_id else "" }}';
+        let autoSaveTimer = null;
+        let isEditMode = {{ 'true' if is_edit_mode else 'false' }};
+        let isCompleted = {{ 'true' if is_completed else 'false' }};
+        
         // Counter for dynamic entries
         let educationCount = 1;
         let achievementCount = 1;
@@ -2461,7 +2538,183 @@
     // Initialize font settings inputs on page load
     document.addEventListener('DOMContentLoaded', function() {
         updateFontSettingsInputs();
+        
+        // Initialize auto-save if resume ID exists
+        if (currentResumeId) {
+            initializeAutoSave();
+            showResumeInfo();
+        }
+        
+        // Add beforeunload event for URL copy popup
+        window.addEventListener('beforeunload', function(e) {
+            if (currentResumeId && !isCompleted) {
+                e.preventDefault();
+                e.returnValue = 'Please copy the URL to edit later your resume.';
+                return e.returnValue;
+            }
+        });
     });
+    
+    // Auto-save functionality
+    function initializeAutoSave() {
+        const form = document.getElementById('cvForm');
+        if (!form) return;
+        
+        // Auto-save on form changes
+        form.addEventListener('input', function() {
+            clearTimeout(autoSaveTimer);
+            autoSaveTimer = setTimeout(function() {
+                autoSaveDraft();
+            }, 2000); // Save after 2 seconds of inactivity
+        });
+        
+        // Auto-save on form submission
+        form.addEventListener('submit', function() {
+            clearTimeout(autoSaveTimer);
+            autoSaveDraft();
+        });
+    }
+    
+    // Auto-save draft data
+    async function autoSaveDraft() {
+        if (!currentResumeId) return Promise.resolve();
+        
+        try {
+            const form = document.getElementById('cvForm');
+            const formData = new FormData(form);
+            
+            const response = await fetch(`/resume/${currentResumeId}/save`, {
+                method: 'POST',
+                body: formData
+            });
+            
+            if (response.ok) {
+                console.log('Draft saved successfully');
+                // Don't show notification for auto-save to avoid spam
+                return Promise.resolve();
+            } else {
+                console.error('Failed to save draft');
+                return Promise.reject('Failed to save draft');
+            }
+        } catch (error) {
+            console.error('Error saving draft:', error);
+            return Promise.reject(error);
+        }
+    }
+    
+    // Show save notification
+    function showSaveNotification(message) {
+        const notification = document.createElement('div');
+        notification.style.cssText = `
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            background-color: #28a745;
+            color: white;
+            padding: 10px 20px;
+            border-radius: 5px;
+            z-index: 1000;
+            font-size: 14px;
+        `;
+        notification.textContent = message;
+        document.body.appendChild(notification);
+        
+        setTimeout(() => {
+            notification.remove();
+        }, 3000);
+    }
+    
+    // Show resume information and controls
+    function showResumeInfo() {
+        const header = document.querySelector('.header');
+        if (!header) return;
+        
+        const resumeInfo = document.createElement('div');
+        resumeInfo.style.cssText = `
+            background-color: #e3f2fd;
+            border: 1px solid #2196f3;
+            border-radius: 5px;
+            padding: 15px;
+            margin-bottom: 20px;
+            text-align: center;
+        `;
+        
+        const currentUrl = window.location.href;
+        const shareUrl = currentUrl + '/view';
+        
+        resumeInfo.innerHTML = `
+            <div style="margin-bottom: 10px;">
+                <strong>Resume ID:</strong> ${currentResumeId}
+            </div>
+            <div style="margin-bottom: 15px;">
+                <strong>Edit URL (Copy this to return later):</strong> 
+                <input type="text" value="${currentUrl}" readonly style="width: 300px; padding: 5px; margin-left: 10px;">
+                <button type="button" onclick="copyToClipboard('${currentUrl}')" style="margin-left: 10px; padding: 5px 10px; background-color: #2196f3; color: white; border: none; border-radius: 3px; cursor: pointer;">
+                    Copy Edit URL
+                </button>
+            </div>
+            <div style="margin-bottom: 15px;">
+                <strong>Share URL (For others to view only):</strong> 
+                <input type="text" value="${shareUrl}" readonly style="width: 300px; padding: 5px; margin-left: 10px;">
+                <button type="button" onclick="copyToClipboard('${shareUrl}')" style="margin-left: 10px; padding: 5px 10px; background-color: #4caf50; color: white; border: none; border-radius: 3px; cursor: pointer;">
+                    Copy Share URL
+                </button>
+            </div>
+            <div style="font-size: 12px; color: #666;">
+                💡 <strong>Auto-save is enabled!</strong> Your work is automatically saved every 2 seconds.
+                <br>💡 <strong>Tip:</strong> Copy the Edit URL to return to edit this resume later. 
+                Click "Copy Share URL" to copy the shareable link for others to view your resume.
+            </div>
+        `;
+        
+        header.parentNode.insertBefore(resumeInfo, header.nextSibling);
+    }
+    
+    // Copy text to clipboard
+    function copyToClipboard(text) {
+        navigator.clipboard.writeText(text).then(function() {
+            showSaveNotification('✅ URL copied to clipboard!');
+        }).catch(function(err) {
+            console.error('Could not copy text: ', err);
+            // Fallback for older browsers
+            const textArea = document.createElement('textarea');
+            textArea.value = text;
+            document.body.appendChild(textArea);
+            textArea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textArea);
+            showSaveNotification('✅ URL copied to clipboard!');
+        });
+    }
+    
+    // Copy edit URL function
+    function copyEditUrl() {
+        const currentUrl = window.location.href;
+        copyToClipboard(currentUrl);
+    }
+    
+    // Share resume function
+    function shareResume() {
+        if (!currentResumeId) return;
+        
+        // First, save the current draft
+        autoSaveDraft().then(() => {
+            // Then copy the share URL to clipboard
+            const shareUrl = window.location.href + '/view';
+            copyToClipboard(shareUrl);
+        });
+    }
+    
+    // Generate CV function
+    function generateCV() {
+        if (!currentResumeId) return;
+        
+        // Submit the hidden CV generation form
+        const cvForm = document.getElementById('cvGenerateForm');
+        if (cvForm) {
+            cvForm.submit();
+        }
+    }
     </script>
 </body>
 </html>

--- a/templates/form.html
+++ b/templates/form.html
@@ -1033,6 +1033,16 @@
             }
             return null;
         }
+
+        function clearLocalStorage() {
+            try {
+                localStorage.removeItem('lastResumeId');
+                localStorage.removeItem('lastResumeTimestamp');
+                console.log('Cleared localStorage due to invalid resume ID');
+            } catch (e) {
+                console.warn('Failed to clear localStorage:', e);
+            }
+        }
         let autoSaveTimer = null;
         let isEditMode = {{ 'true' if is_edit_mode else 'false' }};
         let isCompleted = {{ 'true' if is_completed else 'false' }};
@@ -2633,6 +2643,15 @@
             initializeAutoSave();
             showResumeInfo();
             saveToLocalStorage(currentResumeId);
+            
+            // Check if localStorage has a different UUID - if so, clear it
+            // This handles cases where user manually navigated to a different UUID
+            const storedId = getLastResumeFromStorage();
+            if (storedId && storedId !== currentResumeId) {
+                console.log('Current resume ID differs from stored ID, updating localStorage');
+                // Don't clear completely, just update with current ID
+                saveToLocalStorage(currentResumeId);
+            }
         }
 
         // Add beforeunload event for URL copy popup

--- a/templates/form.html
+++ b/templates/form.html
@@ -1033,16 +1033,6 @@
             }
             return null;
         }
-
-        function clearLocalStorage() {
-            try {
-                localStorage.removeItem('lastResumeId');
-                localStorage.removeItem('lastResumeTimestamp');
-                console.log('Cleared localStorage due to invalid resume ID');
-            } catch (e) {
-                console.warn('Failed to clear localStorage:', e);
-            }
-        }
         let autoSaveTimer = null;
         let isEditMode = {{ 'true' if is_edit_mode else 'false' }};
         let isCompleted = {{ 'true' if is_completed else 'false' }};
@@ -2631,7 +2621,24 @@
         if (window.location.pathname === '/') {
             const lastId = getLastResumeFromStorage();
             if (lastId) {
-                window.location.href = `/?resume_id=${encodeURIComponent(lastId)}`;
+                // Validate existence before redirecting
+                fetch(`/api/v1/resume/${encodeURIComponent(lastId)}/exists`, { cache: 'no-store' })
+                    .then(r => r.json())
+                    .then(j => {
+                        if (j && j.exists) {
+                            window.location.href = `/?resume_id=${encodeURIComponent(lastId)}`;
+                        } else {
+                            try {
+                                localStorage.removeItem('lastResumeId');
+                                localStorage.removeItem('lastResumeTimestamp');
+                            } catch (e) {}
+                            window.location.href = '/?new=1';
+                        }
+                    })
+                    .catch(() => {
+                        // On error, just start fresh to avoid dead-end
+                        window.location.href = '/?new=1';
+                    });
                 return;
             }
         }
@@ -2643,15 +2650,6 @@
             initializeAutoSave();
             showResumeInfo();
             saveToLocalStorage(currentResumeId);
-            
-            // Check if localStorage has a different UUID - if so, clear it
-            // This handles cases where user manually navigated to a different UUID
-            const storedId = getLastResumeFromStorage();
-            if (storedId && storedId !== currentResumeId) {
-                console.log('Current resume ID differs from stored ID, updating localStorage');
-                // Don't clear completely, just update with current ID
-                saveToLocalStorage(currentResumeId);
-            }
         }
 
         // Add beforeunload event for URL copy popup

--- a/templates/root_choice.html
+++ b/templates/root_choice.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Welcome | CV Generator</title>
+  <style>
+    body { font-family: Arial, sans-serif; display: flex; align-items: center; justify-content: center; min-height: 80vh; margin: 0; }
+    .card { border: 1px solid #e0e0e0; border-radius: 8px; padding: 24px; max-width: 520px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.06); }
+    h1 { margin: 0 0 8px 0; font-size: 22px; }
+    p { margin: 0 0 20px 0; color: #555; }
+    .btn { display: inline-block; border: none; background: #4C5196; color: #fff; padding: 10px 16px; border-radius: 6px; cursor: pointer; margin-right: 12px; }
+    .btn.secondary { background: #6c757d; }
+    .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .actions { display: flex; gap: 12px; flex-wrap: wrap; }
+    .hint { font-size: 12px; color: #666; margin-top: 14px; }
+  </style>
+  <noscript>
+    <meta http-equiv="refresh" content="0; url=/?new=1" />
+  </noscript>
+</head>
+<body>
+  <div class="card">
+    <h1>Welcome to CV Generator</h1>
+    <p>Pick an option to get started.</p>
+    <div class="actions">
+      <button id="continueBtn" class="btn" disabled>Continue where you left off</button>
+      <button id="newBtn" class="btn secondary">Start a new resume</button>
+    </div>
+    <div id="hint" class="hint"></div>
+  </div>
+
+  <script>
+    (function () {
+      var continueBtn = document.getElementById('continueBtn');
+      var newBtn = document.getElementById('newBtn');
+      var hint = document.getElementById('hint');
+
+      function getLastResume() {
+        try {
+          var id = localStorage.getItem('lastResumeId');
+          var ts = localStorage.getItem('lastResumeTimestamp');
+          if (!id || !ts) return null;
+          var age = Date.now() - Number(ts);
+          if (isNaN(age)) return id;
+          if (age < 7 * 24 * 60 * 60 * 1000) return id;
+        } catch (e) { /* ignore */ }
+        return null;
+      }
+
+      var lastId = getLastResume();
+      if (lastId) {
+        continueBtn.disabled = false;
+        hint.textContent = 'Found a recent resume. You can continue or start a new one.';
+      } else {
+        // If nothing is found, skip UI and go straight to new
+        window.location.replace('/?new=1');
+        return;
+      }
+
+      continueBtn.addEventListener('click', function () {
+        if (!lastId) return;
+        window.location.href = '/?resume_id=' + encodeURIComponent(lastId);
+      });
+      newBtn.addEventListener('click', function () {
+        window.location.href = '/?new=1';
+      });
+    })();
+  </script>
+</body>
+</html>
+

--- a/templates/root_choice.html
+++ b/templates/root_choice.html
@@ -48,10 +48,37 @@
         return null;
       }
 
+      function clearLocalStorage() {
+        try {
+          localStorage.removeItem('lastResumeId');
+          localStorage.removeItem('lastResumeTimestamp');
+        } catch (e) { /* ignore */ }
+      }
+
+      function checkResumeExists(resumeId, callback) {
+        fetch('/api/resume/' + encodeURIComponent(resumeId) + '/exists')
+          .then(function(response) { return response.json(); })
+          .then(function(data) { callback(data.exists); })
+          .catch(function() { callback(false); });
+      }
+
       var lastId = getLastResume();
       if (lastId) {
-        continueBtn.disabled = false;
-        hint.textContent = 'Found a recent resume. You can continue or start a new one.';
+        // Validate that the resume still exists in storage
+        hint.textContent = 'Checking if your recent resume is still available...';
+        checkResumeExists(lastId, function(exists) {
+          if (exists) {
+            continueBtn.disabled = false;
+            hint.textContent = 'Found a recent resume. You can continue or start a new one.';
+          } else {
+            // Resume no longer exists - clear localStorage and redirect to new
+            clearLocalStorage();
+            hint.textContent = 'Your previous resume is no longer available. Creating a new one...';
+            setTimeout(function() {
+              window.location.replace('/?new=1');
+            }, 1500);
+          }
+        });
       } else {
         // If nothing is found, skip UI and go straight to new
         window.location.replace('/?new=1');

--- a/templates/root_choice.html
+++ b/templates/root_choice.html
@@ -48,37 +48,32 @@
         return null;
       }
 
-      function clearLocalStorage() {
-        try {
-          localStorage.removeItem('lastResumeId');
-          localStorage.removeItem('lastResumeTimestamp');
-        } catch (e) { /* ignore */ }
-      }
-
-      function checkResumeExists(resumeId, callback) {
-        fetch('/api/resume/' + encodeURIComponent(resumeId) + '/exists')
-          .then(function(response) { return response.json(); })
-          .then(function(data) { callback(data.exists); })
-          .catch(function() { callback(false); });
-      }
-
       var lastId = getLastResume();
       if (lastId) {
-        // Validate that the resume still exists in storage
-        hint.textContent = 'Checking if your recent resume is still available...';
-        checkResumeExists(lastId, function(exists) {
-          if (exists) {
-            continueBtn.disabled = false;
-            hint.textContent = 'Found a recent resume. You can continue or start a new one.';
-          } else {
-            // Resume no longer exists - clear localStorage and redirect to new
-            clearLocalStorage();
-            hint.textContent = 'Your previous resume is no longer available. Creating a new one...';
-            setTimeout(function() {
+        // Validate with server before enabling continue button
+        try {
+          fetch('/api/v1/resume/' + encodeURIComponent(lastId) + '/exists', { cache: 'no-store' })
+            .then(function(resp) { return resp.json(); })
+            .then(function(json) {
+              if (json && json.exists) {
+                continueBtn.disabled = false;
+                hint.textContent = 'Found a recent resume. You can continue or start a new one.';
+              } else {
+                // Clear invalid localStorage and start new
+                try {
+                  localStorage.removeItem('lastResumeId');
+                  localStorage.removeItem('lastResumeTimestamp');
+                } catch (e) { /* ignore */ }
+                window.location.replace('/?new=1');
+              }
+            })
+            .catch(function() {
+              // On network error, fallback to new to avoid a broken continue flow
               window.location.replace('/?new=1');
-            }, 1500);
-          }
-        });
+            });
+        } catch (e) {
+          window.location.replace('/?new=1');
+        }
       } else {
         // If nothing is found, skip UI and go straight to new
         window.location.replace('/?new=1');

--- a/templates/root_redirect.html
+++ b/templates/root_redirect.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CV Generator</title>
+    <noscript>
+        JavaScript is required. Redirecting to start a new resume...
+        <meta http-equiv="refresh" content="0; url=/?new=1" />
+    </noscript>
+    <script>
+        (function () {
+            try {
+                var id = localStorage.getItem('lastResumeId');
+                var ts = localStorage.getItem('lastResumeTimestamp');
+                var within = true;
+                if (ts) {
+                    var age = Date.now() - Number(ts);
+                    within = !isNaN(age) && age < (7 * 24 * 60 * 60 * 1000);
+                }
+                if (id && within) {
+                    window.location.replace('/?resume_id=' + encodeURIComponent(id));
+                    return;
+                }
+            } catch (e) { /* ignore */ }
+            // No usable localStorage; start a new resume
+            window.location.replace('/?new=1');
+        })();
+    </script>
+</head>
+<body>
+    Redirecting...
+</body>
+</html>
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -142,11 +142,72 @@ resource "aws_iam_instance_profile" "ec2_profile" {
   role = aws_iam_role.ec2_role.name
 }
 
+# Application S3 bucket for resume storage
+resource "aws_s3_bucket" "app_bucket" {
+  bucket = var.app_s3_bucket_name
+
+  tags = {
+    Name = "${var.project_name}-app-bucket"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "app_bucket" {
+  bucket = aws_s3_bucket.app_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "app_bucket" {
+  bucket = aws_s3_bucket.app_bucket.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "app_bucket" {
+  bucket                  = aws_s3_bucket.app_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+data "aws_iam_policy_document" "app_s3_access" {
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.app_bucket.arn]
+  }
+
+  statement {
+    actions = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = [
+      "${aws_s3_bucket.app_bucket.arn}/${var.app_s3_prefix}resumes/*",
+      "${aws_s3_bucket.app_bucket.arn}/${var.app_s3_prefix}metadata/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "app_s3_policy" {
+  name   = "${var.project_name}-app-s3"
+  policy = data.aws_iam_policy_document.app_s3_access.json
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_app_s3" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = aws_iam_policy.app_s3_policy.arn
+}
+
 # User data script for setting up the application
 locals {
   user_data = base64encode(templatefile("${path.module}/user_data.sh", {
-    repo_url = var.repo_url
-    domain   = "${var.domain}.${var.cloudflare_zone_name}"
+    repo_url          = var.repo_url
+    domain            = "${var.domain}.${var.cloudflare_zone_name}"
+    app_s3_bucket_name = var.app_s3_bucket_name
+    app_s3_prefix      = var.app_s3_prefix
+    aws_region         = var.aws_region
   }))
 }
 
@@ -227,3 +288,13 @@ output "http_redirect_url" {
   description = "HTTP URL that redirects to HTTPS"
   value       = "http://${var.domain}.${var.cloudflare_zone_name}"
 } 
+
+output "app_s3_bucket_name" {
+  description = "Application S3 bucket name"
+  value       = aws_s3_bucket.app_bucket.bucket
+}
+
+output "app_s3_bucket_arn" {
+  description = "Application S3 bucket ARN"
+  value       = aws_s3_bucket.app_bucket.arn
+}

--- a/terraform/user_data.sh
+++ b/terraform/user_data.sh
@@ -132,6 +132,10 @@ Group=cvapp
 WorkingDirectory=/home/cvapp/app
 Environment=PATH=/home/cvapp/app/venv/bin
 Environment=PYTHONPATH=/home/cvapp/app
+Environment=RESUME_STORAGE_TYPE=s3
+Environment=S3_BUCKET_NAME=${app_s3_bucket_name}
+Environment=S3_PREFIX=${app_s3_prefix}
+Environment=AWS_REGION=${aws_region}
 ExecStart=/home/cvapp/app/venv/bin/uvicorn main:app --host 127.0.0.1 --port 8000 --workers 1
 Restart=always
 RestartSec=3

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,3 +52,14 @@ variable "domain" {
   type        = string
   default     = "cv-generator"
 } 
+
+variable "app_s3_bucket_name" {
+  description = "S3 bucket name for application resume storage"
+  type        = string
+}
+
+variable "app_s3_prefix" {
+  description = "Optional S3 key prefix (e.g., env/)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
✨ Summary
Adds UUID-based resume persistence with auto-save, editing, and sharing capabilities. Users can now create resumes that persist across sessions, edit them anytime, and share view-only links with others.
�� Key Features
UUID-based URLs for persistent resume storage
Auto-save every 2 seconds while typing
Edit URL (/resume/{uuid}) for full editing capabilities
View URL (/resume/{uuid}/view) for sharing read-only access
Copy buttons for easy URL sharing
Local storage with JSON files in resume_data/ directory
🏗️ Technical Changes
New ResumeStorageService for data persistence
5 new API endpoints for resume management
Enhanced form with auto-save functionality
View-only templates for professional sharing
Updated CV templates to support new features
�� User Benefits
Never lose resume progress
Easy sharing with employers/colleagues
Professional preview mode for sharing
Work on resumes across multiple sessions
Share even incomplete drafts
�� Files Changed
main.py - New API endpoints
templates/form.html - Enhanced UI with auto-save
app/services/resume_storage_service.py - New storage service
CV templates - View-only mode support
RESUME_FEATURE_README.md - Documentation
Ready for review and deployment! 🎉